### PR TITLE
fix: 修复记忆注入提示词中记忆时间为空的问题 (#85)

### DIFF
--- a/core/event_handler.py
+++ b/core/event_handler.py
@@ -210,6 +210,7 @@ class EventHandler:
                             "content": mem.content,
                             "score": mem.final_score,
                             "metadata": mem.metadata,
+                            "timestamp": mem.metadata.get("create_time"),
                         }
                         for mem in recalled_memories
                     ]

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -335,7 +335,7 @@ def format_memories_for_injection(memories: list) -> str:
                 content = mem.get("content", "内容缺失")
                 score = mem.get("score", 0.0)
                 metadata = mem.get("metadata", {})
-                timestamp = mem.get("timestamp", None)
+                timestamp = mem.get("timestamp") or metadata.get("create_time")
                 importance = metadata.get("importance", 0.5)
                 interaction_type = metadata.get("interaction_type", "未知")
             else:
@@ -349,6 +349,8 @@ def format_memories_for_injection(memories: list) -> str:
                     if isinstance(metadata_raw, str)
                     else metadata_raw
                 )
+                if not timestamp:
+                    timestamp = metadata.get("create_time")
                 importance = metadata.get("importance", 0.5)
                 interaction_type = metadata.get("interaction_type", "未知")
 
@@ -357,13 +359,14 @@ def format_memories_for_injection(memories: list) -> str:
             if timestamp:
                 try:
                     dt = datetime.fromtimestamp(validate_timestamp(timestamp))
-                    time_str = f", 时间: {dt.strftime('%Y-%m-%d %H:%M')}"
+                    time_str = dt.strftime('%Y-%m-%d %H:%M')
                 except Exception:
                     pass
 
             # 构建格式化的记忆条目（展示content和元数据信息）
+            time_part = f", 记忆写入时间: {time_str}" if time_str else ""
             entry_parts = [
-                f"记忆 #{idx} (重要性: {importance:.2f}),发生时间:{time_str}"
+                f"记忆 #{idx} (重要性: {importance:.2f}){time_part}"
             ]
 
             # 添加元数据信息


### PR DESCRIPTION
Closes #85

# 问题

  记忆注入到提示词后，显示效果是这样的：
```
  记忆 #1 (重要性: 0.70),发生时间:
  主题: ...
```
  "发生时间:"后面是空的，LLM 无法知道这条记忆是什么时候产生的。

  如果时间恰好能取到，还会出现标签重复的问题：
```
  记忆 #1 (重要性: 0.70),发生时间:, 时间: 2026-03-13 13:11
```
# 原因

  记忆检索返回的 HybridResult 对象没有 timestamp 字段，时间信息实际是在 metadata.create_time 里边。但构建注入数据时没有把它取出来，格式化函数也没有去 metadata 里找，导致时间始终为空。

# 解决方案

  1. 数据源头补全：构建记忆列表时，从 metadata.create_time 取出时间放到 timestamp 字段
  2. 格式化函数兜底：当 timestamp 取不到时，回退读取 metadata.create_time，避免其他调用方遗漏的情况
  3. 修复显示格式：去掉重复的标签拼接，改为有时间时显示 记忆写入时间: 2026-03-13 13:11，没有时间时不显示，不再留空

# 修复后

```xml
<RAG-Faiss-Memory>
以下是从历史对话中提取的相关记忆，可以帮助你更好地理解用户的背景、偏好和过往交流内容。
请参考这些记忆来提供更个性化、更连贯的回答。

记忆 #1 (重要性: 0.70), 记忆写入时间: 2026-03-13 13:11
主题: 机器人功能调试、对话记忆总结 | 参与者: Lincannm、我(Bot) | 关键信息: Lincannm于2026-03-13 13:10在群内at我发送文字内容“嗯嗯”; 本次未收到任何原生图片输入，共0张; 我按照调试要求回复了收到内容的概要信息; Lincannm发送指令/lmem summarize要求生成对话记忆总结
2026-03-13我在群聊里，先看到Lincannm at我发送了文字“嗯嗯”，我按照调试要求回复了本次收到的内容概要，说明我没有收到原生图片输入，一共0张，也说明了Lincannm的发言信息，之后Lincannm发送了/lmem summarize指令，要求我完成这次对话记忆总结任务。 | Lincannm于2026-03-13 13:10在群内at我发送文字内容“嗯嗯”；本次未收到任何原生图片输入，共0张；我按照调试要求回复了收到内容的概要信息；Lincannm发送指令/lmem summarize要求生成对话记忆总结

注意：以上记忆来自历史对话，请结合当前对话上下文使用这些信息。
</RAG-Faiss-Memory>
```