### PR TITLE
feat: add fake tool call injection strategy

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -113,13 +113,14 @@
       },
       "injection_method": {
         "description": "记忆注入位置",
-        "hint": "记忆注入到 LLM 请求的位置。user_message_before：作为用户消息前缀；system_prompt：追加到系统提示词；user_message_after：作为用户消息后缀。",
+        "hint": "记忆注入到 LLM 请求的位置。user_message_before：作为用户消息前缀；system_prompt：追加到系统提示词；user_message_after：作为用户消息后缀；fake_tool_call：伪造工具调用消息对注入到对话历史，使 LLM 自然地理解这是检索结果。",
         "type": "string",
         "default": "user_message_before",
         "options": [
           "user_message_before",
           "system_prompt",
-          "user_message_after"
+          "user_message_after",
+          "fake_tool_call"
         ]
       },
       "auto_remove_injected": {

--- a/core/base/config_validator.py
+++ b/core/base/config_validator.py
@@ -46,7 +46,7 @@ class RecallEngineConfig(BaseModel):
     fallback_to_vector: bool = Field(default=True, description="是否启用向量检索回退")
     injection_method: str = Field(
         default="user_message_before",
-        description="记忆注入方式: system_prompt(系统提示), user_message_before(用户消息前), user_message_after(用户消息后)",
+        description="记忆注入方式: system_prompt(系统提示), user_message_before(用户消息前), user_message_after(用户消息后), fake_tool_call(伪造工具调用)",
     )
     auto_remove_injected: bool = Field(
         default=True, description="是否自动删除对话历史中已注入的记忆片段"

--- a/core/base/constants.py
+++ b/core/base/constants.py
@@ -5,3 +5,7 @@ constants.py - 插件使用的常量
 # 注入到 System Prompt 的记忆头尾格式
 MEMORY_INJECTION_HEADER = "<RAG-Faiss-Memory>"
 MEMORY_INJECTION_FOOTER = "</RAG-Faiss-Memory>"
+
+# 伪造工具调用注入相关常量
+FAKE_TOOL_CALL_NAME = "recall_long_term_memory"  # 复用已注册的工具名
+FAKE_TOOL_CALL_ID_PREFIX = "fake_recall_"  # ID 前缀，用于清理时识别伪造消息

--- a/core/event_handler.py
+++ b/core/event_handler.py
@@ -252,6 +252,8 @@ class EventHandler:
                             k=self.config_manager.get(
                                 "recall_engine.top_k", 5
                             ),
+                            session_filtered=use_session_filtering,
+                            persona_filtered=use_persona_filtering,
                         )
                         if fake_messages:
                             req.contexts.extend(fake_messages)

--- a/core/event_handler.py
+++ b/core/event_handler.py
@@ -211,6 +211,7 @@ class EventHandler:
                     # 格式化并注入记忆
                     memory_list = [
                         {
+                            "id": getattr(mem, "doc_id", None),
                             "content": mem.content,
                             "score": mem.final_score,
                             "metadata": mem.metadata,

--- a/core/event_handler.py
+++ b/core/event_handler.py
@@ -19,6 +19,7 @@ from .managers.memory_engine import MemoryEngine
 from .processors.memory_processor import MemoryProcessor
 from .utils import (
     OperationContext,
+    format_memories_for_fake_tool_call,
     format_memories_for_injection,
     get_persona_id,
 )
@@ -152,6 +153,9 @@ class EventHandler:
                     removed = self._remove_injected_memories_from_context(
                         req, session_id
                     )
+                    removed += self._remove_fake_tool_call_from_context(
+                        req, session_id
+                    )
                     if removed > 0:
                         logger.info(
                             f"[{session_id}] 已清理 {removed} 处历史记忆注入片段"
@@ -240,6 +244,20 @@ class EventHandler:
                         logger.info(
                             f"[{session_id}] 成功向用户消息后注入 {len(recalled_memories)} 条记忆"
                         )
+                    elif injection_method == "fake_tool_call":
+                        fake_messages = format_memories_for_fake_tool_call(
+                            memory_list,
+                            query=actual_query,
+                            k=self.config_manager.get(
+                                "recall_engine.top_k", 5
+                            ),
+                        )
+                        if fake_messages:
+                            req.contexts.extend(fake_messages)
+                            logger.info(
+                                f"[{session_id}] 成功以伪造工具调用方式注入 "
+                                f"{len(recalled_memories)} 条记忆"
+                            )
                     else:
                         # system_prompt 注入：记忆追加到末尾，确保人格提示词在前
                         req.system_prompt = (
@@ -865,6 +883,73 @@ class EventHandler:
             logger.error(f"[{session_id}] 删除注入记忆时发生错误: {e}", exc_info=True)
 
         return removed_count
+
+    def _remove_fake_tool_call_from_context(
+        self, req: ProviderRequest, session_id: str
+    ) -> int:
+        """从对话历史中删除伪造的工具调用消息对。
+
+        识别并移除以 FAKE_TOOL_CALL_ID_PREFIX 为 ID 前缀的
+        assistant(tool_calls) + tool(result) 消息对。
+
+        Args:
+            req: LLM 请求对象。
+            session_id: 会话 ID，用于日志。
+
+        Returns:
+            删除的消息数量。
+        """
+        from .base.constants import FAKE_TOOL_CALL_ID_PREFIX
+
+        if not hasattr(req, "contexts") or not req.contexts:
+            return 0
+
+        removed = 0
+        indices_to_remove: set[int] = set()
+        fake_call_ids: set[str] = set()
+
+        try:
+            # 第一轮扫描：找到所有伪造的 assistant 消息和对应的 call_id
+            for i, msg in enumerate(req.contexts):
+                if not isinstance(msg, dict):
+                    continue
+                if msg.get("role") == "assistant" and msg.get("tool_calls"):
+                    for tc in msg["tool_calls"]:
+                        tc_id = (
+                            tc.get("id", "")
+                            if isinstance(tc, dict)
+                            else getattr(tc, "id", "")
+                        )
+                        if tc_id.startswith(FAKE_TOOL_CALL_ID_PREFIX):
+                            fake_call_ids.add(tc_id)
+                            indices_to_remove.add(i)
+
+            # 第二轮扫描：找到对应的 tool 消息
+            for i, msg in enumerate(req.contexts):
+                if not isinstance(msg, dict):
+                    continue
+                if msg.get("role") == "tool":
+                    tc_id = msg.get("tool_call_id", "")
+                    if tc_id in fake_call_ids:
+                        indices_to_remove.add(i)
+
+            # 从后往前删除，避免索引偏移
+            for i in sorted(indices_to_remove, reverse=True):
+                req.contexts.pop(i)
+                removed += 1
+
+            if removed > 0:
+                logger.info(
+                    f"[{session_id}] 清理了 {removed} 条伪造工具调用消息"
+                )
+
+        except Exception as e:
+            logger.error(
+                f"[{session_id}] 清理伪造工具调用时发生错误: {e}",
+                exc_info=True,
+            )
+
+        return removed
 
     async def _build_dedup_key(
         self, event: AstrMessageEvent, session_id: str, content: str

--- a/core/retrieval/graph_keyword_retriever.py
+++ b/core/retrieval/graph_keyword_retriever.py
@@ -48,7 +48,7 @@ class GraphKeywordRetriever:
         if not tokens:
             return []
 
-        escaped_tokens = [f'"{token.replace('"', '""')}"' for token in tokens]
+        escaped_tokens = ['"' + token.replace('"', '""') + '"' for token in tokens]
         fts_query = " OR ".join(escaped_tokens)
 
         direct_hits = await self.graph_store.search_entries_by_bm25(

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -442,6 +442,8 @@ def format_memories_for_fake_tool_call(
     memories: list,
     query: str,
     k: int = 5,
+    session_filtered: bool = True,
+    persona_filtered: bool = True,
 ) -> list[dict]:
     """将检索到的记忆列表格式化为伪造的工具调用消息对。
 
@@ -456,6 +458,8 @@ def format_memories_for_fake_tool_call(
         memories: 记忆字典列表，每条包含 content、score、metadata、timestamp 字段。
         query: 用户查询文本（作为工具调用参数）。
         k: 召回数量（作为工具调用参数）。
+        session_filtered: 本次检索是否启用了会话过滤。
+        persona_filtered: 本次检索是否启用了人格过滤。
 
     Returns:
         两条 OpenAI 格式消息的列表 [assistant_msg, tool_msg]；
@@ -510,6 +514,10 @@ def format_memories_for_fake_tool_call(
     tool_result_json = json.dumps(
         {
             "query": query[:200],
+            "applied_filters": {
+                "session_filtered": session_filtered,
+                "persona_filtered": persona_filtered,
+            },
             "count": len(serialized_results),
             "results": serialized_results,
         },

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -438,6 +438,111 @@ def format_memories_for_injection(memories: list) -> str:
     return result
 
 
+def format_memories_for_fake_tool_call(
+    memories: list,
+    query: str,
+    k: int = 5,
+) -> list[dict]:
+    """将检索到的记忆列表格式化为伪造的工具调用消息对。
+
+    生成两条 OpenAI 格式的消息：
+    1. assistant 消息，包含 tool_calls（调用 recall_long_term_memory）
+    2. tool 消息，包含工具调用结果（记忆内容，JSON 格式）
+
+    返回的 JSON 格式与 MemorySearchTool.call() 的真实返回值保持一致，
+    使 LLM 对伪造调用和真实调用有相同的理解。
+
+    Args:
+        memories: 记忆字典列表，每条包含 content、score、metadata、timestamp 字段。
+        query: 用户查询文本（作为工具调用参数）。
+        k: 召回数量（作为工具调用参数）。
+
+    Returns:
+        两条 OpenAI 格式消息的列表 [assistant_msg, tool_msg]；
+        若 memories 为空则返回空列表。
+    """
+    import uuid
+
+    from ..base.constants import FAKE_TOOL_CALL_ID_PREFIX, FAKE_TOOL_CALL_NAME
+
+    if not memories:
+        return []
+
+    # 生成唯一的伪造调用 ID
+    call_id = f"{FAKE_TOOL_CALL_ID_PREFIX}{uuid.uuid4().hex[:12]}"
+
+    # 将记忆序列化为与 MemorySearchTool.call() 一致的 JSON 格式
+    serialized_results = []
+    for mem in memories:
+        if isinstance(mem, dict):
+            content = mem.get("content", "")
+            score = mem.get("score", 0.0)
+            metadata = mem.get("metadata", {})
+        else:
+            content = getattr(mem, "content", "")
+            score = getattr(mem, "score", 0.0)
+            metadata_raw = getattr(mem, "metadata", {})
+            metadata = (
+                safe_parse_metadata(metadata_raw)
+                if isinstance(metadata_raw, str)
+                else metadata_raw
+            )
+
+        serialized_results.append(
+            {
+                "content": content,
+                "score": round(score, 4) if isinstance(score, float) else score,
+                "importance": metadata.get("importance", 0.5),
+                "session_id": metadata.get("session_id"),
+                "persona_id": metadata.get("persona_id"),
+                "create_time": metadata.get("create_time"),
+                "last_access_time": metadata.get("last_access_time"),
+            }
+        )
+
+    tool_result_json = json.dumps(
+        {
+            "query": query[:200],
+            "count": len(serialized_results),
+            "results": serialized_results,
+        },
+        ensure_ascii=False,
+    )
+
+    # 构造 assistant 消息（伪造的工具调用）
+    assistant_msg: dict[str, Any] = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {
+                    "name": FAKE_TOOL_CALL_NAME,
+                    "arguments": json.dumps(
+                        {"query": query[:200], "k": k},
+                        ensure_ascii=False,
+                    ),
+                },
+            }
+        ],
+    }
+
+    # 构造 tool 消息（伪造的返回结果）
+    tool_msg: dict[str, Any] = {
+        "role": "tool",
+        "tool_call_id": call_id,
+        "content": tool_result_json,
+    }
+
+    logger.info(
+        f"[format_memories_for_fake_tool_call] "
+        f"生成伪造工具调用: call_id={call_id}, 记忆条数={len(serialized_results)}"
+    )
+
+    return [assistant_msg, tool_msg]
+
+
 __all__ = [
     "StopwordsManager",
     "get_stopwords_manager",
@@ -452,4 +557,5 @@ __all__ = [
     "get_now_datetime",
     "get_now_datetime_from_context",
     "format_memories_for_injection",
+    "format_memories_for_fake_tool_call",
 ]

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -475,12 +475,18 @@ def format_memories_for_fake_tool_call(
     serialized_results = []
     for mem in memories:
         if isinstance(mem, dict):
+            memory_id = mem.get("id", mem.get("doc_id"))
             content = mem.get("content", "")
             score = mem.get("score", 0.0)
             metadata = mem.get("metadata", {})
         else:
+            memory_id = getattr(mem, "doc_id", None)
+            if not isinstance(memory_id, (str, int)):
+                memory_id = getattr(mem, "id", None)
+                if not isinstance(memory_id, (str, int)):
+                    memory_id = None
             content = getattr(mem, "content", "")
-            score = getattr(mem, "score", 0.0)
+            score = getattr(mem, "score", getattr(mem, "final_score", 0.0))
             metadata_raw = getattr(mem, "metadata", {})
             metadata = (
                 safe_parse_metadata(metadata_raw)
@@ -490,6 +496,7 @@ def format_memories_for_fake_tool_call(
 
         serialized_results.append(
             {
+                "id": memory_id,
                 "content": content,
                 "score": round(score, 4) if isinstance(score, float) else score,
                 "importance": metadata.get("importance", 0.5),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,27 +1,404 @@
 """
 pytest 配置文件
-提供测试夹具和工具函数
+提供测试夹具和基础运行环境。
 """
 
 import asyncio
+import logging
 import sys
 import tempfile
+import types
 from collections.abc import Generator
+from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 
 import pytest
 
-# Ensure plugin modules are importable during test module collection.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PLUGINS_DIR = Path(__file__).resolve().parents[2]
-plugins_dir_str = str(PLUGINS_DIR)
-if plugins_dir_str not in sys.path:
-    sys.path.insert(0, plugins_dir_str)
-
-# Ensure AstrBot package is importable for tests that import plugin main module.
 ASTRBOT_ROOT = Path(__file__).resolve().parents[4]
-astrbot_root_str = str(ASTRBOT_ROOT)
-if astrbot_root_str not in sys.path:
-    sys.path.insert(0, astrbot_root_str)
+
+for candidate in (PROJECT_ROOT, PLUGINS_DIR, ASTRBOT_ROOT):
+    candidate_str = str(candidate)
+    if candidate_str not in sys.path:
+        sys.path.insert(0, candidate_str)
+
+
+def _ensure_plugin_package_alias() -> None:
+    """将当前源码目录暴露为测试中使用的包名。"""
+    if "astrbot_plugin_livingmemory" in sys.modules:
+        return
+
+    plugin_pkg = types.ModuleType("astrbot_plugin_livingmemory")
+    plugin_pkg.__path__ = [str(PROJECT_ROOT)]
+    plugin_pkg.__file__ = str(PROJECT_ROOT / "__init__.py")
+    sys.modules["astrbot_plugin_livingmemory"] = plugin_pkg
+
+
+def _install_optional_dependency_stubs() -> None:
+    """为单元测试安装轻量的第三方依赖桩。"""
+    try:
+        import aiosqlite  # type: ignore  # noqa: F401
+    except Exception:
+        aiosqlite_mod = types.ModuleType("aiosqlite")
+
+        class Connection:
+            pass
+
+        async def connect(*args, **kwargs):
+            return Connection()
+
+        aiosqlite_mod.Connection = Connection
+        aiosqlite_mod.connect = connect
+        sys.modules["aiosqlite"] = aiosqlite_mod
+
+    try:
+        import jieba  # type: ignore  # noqa: F401
+    except Exception:
+        jieba_mod = types.ModuleType("jieba")
+        jieba_mod.cut = lambda text, cut_all=False: list(text) if text else []
+        jieba_mod.lcut = lambda text, cut_all=False: list(text) if text else []
+        sys.modules["jieba"] = jieba_mod
+
+    try:
+        import pytz  # type: ignore  # noqa: F401
+    except Exception:
+        pytz_mod = types.ModuleType("pytz")
+        pytz_mod.timezone = lambda name: None
+        sys.modules["pytz"] = pytz_mod
+
+
+def _install_astrbot_stubs() -> None:
+    """安装满足当前单元测试所需的最小 AstrBot 桩模块。"""
+    logger = logging.getLogger("astrbot-test")
+    logger.addHandler(logging.NullHandler())
+
+    class _StorageProxy:
+        async def get_async(self, *args, **kwargs):
+            return None
+
+    class _Filter:
+        def on_llm_request(self):
+            return lambda func: func
+
+        def on_llm_response(self):
+            return lambda func: func
+
+        def after_message_sent(self):
+            return lambda func: func
+
+        def platform_adapter_type(self, *args, **kwargs):
+            return lambda func: func
+
+    class AstrMessageEvent:
+        pass
+
+    class MessageEventResult:
+        pass
+
+    class MessageType(Enum):
+        FRIEND_MESSAGE = "friend"
+        GROUP_MESSAGE = "group"
+
+    @dataclass
+    class ProviderRequest:
+        prompt: str | None = None
+        session_id: str | None = ""
+        image_urls: list = field(default_factory=list)
+        audio_urls: list = field(default_factory=list)
+        extra_user_content_parts: list = field(default_factory=list)
+        func_tool: object | None = None
+        contexts: list = field(default_factory=list)
+        system_prompt: str = ""
+        conversation: object | None = None
+        tool_calls_result: list | None = None
+        model: str | None = None
+
+    @dataclass
+    class LLMResponse:
+        role: str = "assistant"
+        result_chain: object | None = None
+        tools_call_args: list = field(default_factory=list)
+        tools_call_name: list | None = None
+        tools_call_ids: list = field(default_factory=list)
+        tools_call_extra_content: dict | None = None
+        completion_text: str = ""
+
+    class Context:
+        pass
+
+    class Star:
+        pass
+
+    class StarTools:
+        pass
+
+    class FunctionTool:
+        @classmethod
+        def __class_getitem__(cls, item):
+            return cls
+
+    class ToolSet:
+        pass
+
+    ToolExecResult = str
+
+    class BaseFunctionToolExecutor:
+        pass
+
+    class ContextWrapper:
+        @classmethod
+        def __class_getitem__(cls, item):
+            return cls
+
+    class AstrAgentContext:
+        pass
+
+    class AstrBotConfig:
+        pass
+
+    class EmbeddingProvider:
+        pass
+
+    class Provider:
+        pass
+
+    class SQLiteDatabase:
+        pass
+
+    class FaissVecDB:
+        pass
+
+    class _BaseComponent:
+        type = "component"
+
+        def __init__(self, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    class Plain(_BaseComponent):
+        type = "plain"
+
+        def __init__(self, text=""):
+            super().__init__(text=text)
+
+    class Image(_BaseComponent):
+        type = "image"
+
+    class Record(_BaseComponent):
+        type = "record"
+
+    class Video(_BaseComponent):
+        type = "video"
+
+    class File(_BaseComponent):
+        type = "file"
+
+        def __init__(self, name=""):
+            super().__init__(name=name)
+
+    class Face(_BaseComponent):
+        type = "face"
+
+        def __init__(self, id=""):
+            super().__init__(id=id)
+
+    class At(_BaseComponent):
+        type = "at"
+
+        def __init__(self, qq=""):
+            super().__init__(qq=qq)
+
+    class AtAll(At):
+        type = "atall"
+
+    class Forward(_BaseComponent):
+        type = "forward"
+
+    class Reply(_BaseComponent):
+        type = "reply"
+
+        def __init__(self, message_str=""):
+            super().__init__(message_str=message_str)
+
+    def register(*args, **kwargs):
+        return lambda obj: obj
+
+    def register_agent(*args, **kwargs):
+        return lambda obj: obj
+
+    def register_llm_tool(*args, **kwargs):
+        return lambda obj: obj
+
+    class PermissionType(Enum):
+        ADMIN = "admin"
+
+    def permission_type(*args, **kwargs):
+        return lambda func: func
+
+    def _package(name: str) -> types.ModuleType:
+        module = types.ModuleType(name)
+        module.__path__ = []
+        return module
+
+    astrbot_mod = _package("astrbot")
+    astrbot_mod.logger = logger
+
+    api_mod = _package("astrbot.api")
+    api_mod.logger = logger
+    api_mod.sp = _StorageProxy()
+
+    event_mod = _package("astrbot.api.event")
+    event_mod.AstrMessageEvent = AstrMessageEvent
+    event_mod.MessageEventResult = MessageEventResult
+    event_mod.filter = _Filter()
+
+    event_filter_mod = types.ModuleType("astrbot.api.event.filter")
+    event_filter_mod.PermissionType = PermissionType
+    event_filter_mod.permission_type = permission_type
+
+    platform_mod = types.ModuleType("astrbot.api.platform")
+    platform_mod.MessageType = MessageType
+
+    provider_mod = types.ModuleType("astrbot.api.provider")
+    provider_mod.ProviderRequest = ProviderRequest
+    provider_mod.LLMResponse = LLMResponse
+
+    star_mod = types.ModuleType("astrbot.api.star")
+    star_mod.Context = Context
+    star_mod.Star = Star
+    star_mod.StarTools = StarTools
+    star_mod.register = register
+
+    core_mod = _package("astrbot.core")
+    core_mod.sp = api_mod.sp
+    core_mod.html_renderer = None
+
+    core_db_mod = _package("astrbot.core.db")
+    core_vec_db_mod = _package("astrbot.core.db.vec_db")
+    core_faiss_pkg_mod = _package("astrbot.core.db.vec_db.faiss_impl")
+    core_faiss_vec_mod = types.ModuleType("astrbot.core.db.vec_db.faiss_impl.vec_db")
+    core_faiss_vec_mod.FaissVecDB = FaissVecDB
+
+    core_agent_mod = _package("astrbot.core.agent")
+    core_agent_tool_mod = types.ModuleType("astrbot.core.agent.tool")
+    core_agent_tool_mod.FunctionTool = FunctionTool
+    core_agent_tool_mod.ToolSet = ToolSet
+    core_agent_tool_mod.ToolExecResult = ToolExecResult
+
+    core_agent_executor_mod = types.ModuleType("astrbot.core.agent.tool_executor")
+    core_agent_executor_mod.BaseFunctionToolExecutor = BaseFunctionToolExecutor
+
+    core_agent_run_context_mod = types.ModuleType("astrbot.core.agent.run_context")
+    core_agent_run_context_mod.ContextWrapper = ContextWrapper
+
+    core_astr_agent_context_mod = types.ModuleType("astrbot.core.astr_agent_context")
+    core_astr_agent_context_mod.AstrAgentContext = AstrAgentContext
+
+    core_config_mod = _package("astrbot.core.config")
+    core_config_astrbot_mod = types.ModuleType("astrbot.core.config.astrbot_config")
+    core_config_astrbot_mod.AstrBotConfig = AstrBotConfig
+
+    core_star_mod = _package("astrbot.core.star")
+    core_star_register_mod = types.ModuleType("astrbot.core.star.register")
+    core_star_register_mod.register_agent = register_agent
+    core_star_register_mod.register_llm_tool = register_llm_tool
+
+    core_provider_mod = _package("astrbot.core.provider")
+    core_provider_provider_mod = types.ModuleType("astrbot.core.provider.provider")
+    core_provider_provider_mod.EmbeddingProvider = EmbeddingProvider
+    core_provider_provider_mod.Provider = Provider
+
+    core_sqlite_mod = types.ModuleType("astrbot.core.db.sqlite")
+    core_sqlite_mod.SQLiteDatabase = SQLiteDatabase
+
+    core_message_mod = _package("astrbot.core.message")
+    core_message_components_mod = types.ModuleType("astrbot.core.message.components")
+    core_message_components_mod.Plain = Plain
+    core_message_components_mod.Image = Image
+    core_message_components_mod.Record = Record
+    core_message_components_mod.Video = Video
+    core_message_components_mod.File = File
+    core_message_components_mod.Face = Face
+    core_message_components_mod.At = At
+    core_message_components_mod.AtAll = AtAll
+    core_message_components_mod.Forward = Forward
+    core_message_components_mod.Reply = Reply
+
+    sys.modules.update(
+        {
+            "astrbot": astrbot_mod,
+            "astrbot.api": api_mod,
+            "astrbot.api.event": event_mod,
+            "astrbot.api.event.filter": event_filter_mod,
+            "astrbot.api.platform": platform_mod,
+            "astrbot.api.provider": provider_mod,
+            "astrbot.api.star": star_mod,
+            "astrbot.core": core_mod,
+            "astrbot.core.db": core_db_mod,
+            "astrbot.core.db.sqlite": core_sqlite_mod,
+            "astrbot.core.db.vec_db": core_vec_db_mod,
+            "astrbot.core.db.vec_db.faiss_impl": core_faiss_pkg_mod,
+            "astrbot.core.db.vec_db.faiss_impl.vec_db": core_faiss_vec_mod,
+            "astrbot.core.agent": core_agent_mod,
+            "astrbot.core.agent.tool": core_agent_tool_mod,
+            "astrbot.core.agent.tool_executor": core_agent_executor_mod,
+            "astrbot.core.agent.run_context": core_agent_run_context_mod,
+            "astrbot.core.astr_agent_context": core_astr_agent_context_mod,
+            "astrbot.core.config": core_config_mod,
+            "astrbot.core.config.astrbot_config": core_config_astrbot_mod,
+            "astrbot.core.star": core_star_mod,
+            "astrbot.core.star.register": core_star_register_mod,
+            "astrbot.core.provider": core_provider_mod,
+            "astrbot.core.provider.provider": core_provider_provider_mod,
+            "astrbot.core.message": core_message_mod,
+            "astrbot.core.message.components": core_message_components_mod,
+        }
+    )
+
+    astrbot_mod.api = api_mod
+    astrbot_mod.core = core_mod
+    api_mod.event = event_mod
+    api_mod.platform = platform_mod
+    api_mod.provider = provider_mod
+    api_mod.star = star_mod
+    api_mod.FunctionTool = FunctionTool
+    api_mod.ToolSet = ToolSet
+    api_mod.BaseFunctionToolExecutor = BaseFunctionToolExecutor
+    api_mod.AstrBotConfig = AstrBotConfig
+    api_mod.agent = register_agent
+    api_mod.llm_tool = register_llm_tool
+
+    core_mod.db = core_db_mod
+    core_mod.agent = core_agent_mod
+    core_mod.config = core_config_mod
+    core_mod.star = core_star_mod
+    core_mod.provider = core_provider_mod
+    core_mod.message = core_message_mod
+    core_db_mod.sqlite = core_sqlite_mod
+    core_db_mod.vec_db = core_vec_db_mod
+    core_vec_db_mod.faiss_impl = core_faiss_pkg_mod
+    core_faiss_pkg_mod.vec_db = core_faiss_vec_mod
+    core_agent_mod.tool = core_agent_tool_mod
+    core_agent_mod.tool_executor = core_agent_executor_mod
+    core_agent_mod.run_context = core_agent_run_context_mod
+    core_config_mod.astrbot_config = core_config_astrbot_mod
+    core_star_mod.register = core_star_register_mod
+    core_provider_mod.provider = core_provider_provider_mod
+    core_message_mod.components = core_message_components_mod
+
+
+_ensure_plugin_package_alias()
+_install_optional_dependency_stubs()
+
+try:
+    import astrbot.api  # type: ignore  # noqa: F401
+    from astrbot.core.db.vec_db.faiss_impl.vec_db import (  # type: ignore  # noqa: F401
+        FaissVecDB,
+    )
+except Exception:
+    _install_astrbot_stubs()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -533,3 +533,213 @@ async def test_handle_memory_reflection_pending_retry_exceeds_max(
     assert session_metadata.get("pending_summary") is None
     # add_memory 不应被调用（放弃了该范围）
     memory_engine.add_memory.assert_not_awaited()
+
+
+
+# ==================== fake_tool_call 注入策略测试 ====================
+
+
+@pytest.mark.asyncio
+async def test_format_memories_for_fake_tool_call():
+    """format_memories_for_fake_tool_call 应生成正确的伪造工具调用消息对。"""
+    from astrbot_plugin_livingmemory.core.utils import (
+        format_memories_for_fake_tool_call,
+    )
+
+    memories = [
+        {
+            "content": "用户喜欢Python编程",
+            "score": 0.85,
+            "metadata": {
+                "importance": 0.9,
+                "session_id": "s1",
+                "persona_id": "p1",
+                "create_time": 1700000000,
+                "last_access_time": 1700001000,
+            },
+            "timestamp": 1700000000,
+        },
+        {
+            "content": "用户讨论过机器学习项目",
+            "score": 0.72,
+            "metadata": {"importance": 0.7},
+            "timestamp": None,
+        },
+    ]
+
+    result = format_memories_for_fake_tool_call(memories, query="Python", k=5)
+
+    # 应返回 2 条消息
+    assert len(result) == 2
+
+    assistant_msg = result[0]
+    tool_msg = result[1]
+
+    # 验证 assistant 消息格式
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["content"] is None
+    assert len(assistant_msg["tool_calls"]) == 1
+
+    tc = assistant_msg["tool_calls"][0]
+    assert tc["type"] == "function"
+    assert tc["function"]["name"] == "recall_long_term_memory"
+    assert tc["id"].startswith("fake_recall_")
+
+    # 验证 tool 消息格式
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["tool_call_id"] == tc["id"]
+    assert "Python" in tool_msg["content"]
+    assert "用户喜欢Python编程" in tool_msg["content"]
+    assert "用户讨论过机器学习项目" in tool_msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_format_memories_for_fake_tool_call_empty():
+    """空记忆列表应返回空列表。"""
+    from astrbot_plugin_livingmemory.core.utils import (
+        format_memories_for_fake_tool_call,
+    )
+
+    result = format_memories_for_fake_tool_call([], query="test", k=5)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_recall_injection_fake_tool_call(
+    handler, memory_engine
+):
+    """injection_method=fake_tool_call 时，记忆应以伪造工具调用的形式注入到 contexts。"""
+    from astrbot_plugin_livingmemory.core.base.config_manager import ConfigManager
+    from astrbot_plugin_livingmemory.core.event_handler import EventHandler
+
+    h = EventHandler(
+        context=Mock(),
+        config_manager=ConfigManager(
+            {
+                "recall_engine": {
+                    "top_k": 3,
+                    "injection_method": "fake_tool_call",
+                },
+                "reflection_engine": {"summary_trigger_rounds": 1},
+                "session_manager": {"max_messages_per_session": 100},
+            }
+        ),
+        memory_engine=memory_engine,
+        memory_processor=Mock(),
+        conversation_manager=Mock(),
+    )
+    h.conversation_manager.add_message_from_event = AsyncMock()
+
+    recalled = Mock(
+        content="用户喜欢吃火锅",
+        final_score=0.88,
+        metadata={"importance": 0.9, "create_time": 1700000000},
+    )
+    memory_engine.search_memories = AsyncMock(return_value=[recalled])
+
+    event = _make_event(group=False)
+    req = _make_req("今天吃什么")
+
+    with patch(
+        "astrbot_plugin_livingmemory.core.event_handler.get_persona_id",
+        new_callable=AsyncMock,
+    ) as get_persona:
+        get_persona.return_value = "p1"
+        await h.handle_memory_recall(event, req)
+
+    # contexts 应该新增了 2 条消息（assistant + tool）
+    assert len(req.contexts) == 2
+
+    assistant_msg = req.contexts[0]
+    tool_msg = req.contexts[1]
+
+    # 验证 assistant 消息
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["content"] is None
+    assert len(assistant_msg["tool_calls"]) == 1
+    assert assistant_msg["tool_calls"][0]["function"]["name"] == "recall_long_term_memory"
+
+    # 验证 tool 消息
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["tool_call_id"] == assistant_msg["tool_calls"][0]["id"]
+    assert "用户喜欢吃火锅" in tool_msg["content"]
+
+    # prompt 和 system_prompt 不应被修改
+    assert req.prompt == "今天吃什么"
+    assert req.system_prompt == ""
+
+
+@pytest.mark.asyncio
+async def test_remove_fake_tool_call_from_context(handler):
+    """_remove_fake_tool_call_from_context 应正确移除伪造消息对，保留正常消息。"""
+    req = _make_req("hello")
+    req.contexts = [
+        {"role": "user", "content": "你好"},
+        {"role": "assistant", "content": "你好啊"},
+        # 伪造的工具调用消息对
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "fake_recall_abc123def456",
+                    "type": "function",
+                    "function": {
+                        "name": "recall_long_term_memory",
+                        "arguments": '{"query": "test", "k": 5}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "fake_recall_abc123def456",
+            "content": '{"query": "test", "count": 1, "results": []}',
+        },
+        {"role": "user", "content": "最近怎么样"},
+    ]
+
+    removed = handler._remove_fake_tool_call_from_context(req, "test-session")
+
+    # 应删除 2 条伪造消息
+    assert removed == 2
+
+    # 应保留 3 条正常消息
+    assert len(req.contexts) == 3
+    assert req.contexts[0]["content"] == "你好"
+    assert req.contexts[1]["content"] == "你好啊"
+    assert req.contexts[2]["content"] == "最近怎么样"
+
+
+@pytest.mark.asyncio
+async def test_remove_fake_tool_call_preserves_real_tool_calls(handler):
+    """_remove_fake_tool_call_from_context 不应误删真实的工具调用消息。"""
+    req = _make_req("hello")
+    req.contexts = [
+        # 真实的工具调用消息对（ID 不以 fake_recall_ 开头）
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_real_abc123",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city": "上海"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_real_abc123",
+            "content": '{"temperature": 25}',
+        },
+    ]
+
+    removed = handler._remove_fake_tool_call_from_context(req, "test-session")
+
+    # 不应删除任何消息
+    assert removed == 0
+    assert len(req.contexts) == 2

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -569,7 +569,13 @@ async def test_format_memories_for_fake_tool_call():
         },
     ]
 
-    result = format_memories_for_fake_tool_call(memories, query="Python", k=5)
+    result = format_memories_for_fake_tool_call(
+        memories,
+        query="Python",
+        k=5,
+        session_filtered=True,
+        persona_filtered=False,
+    )
 
     # 应返回 2 条消息
     assert len(result) == 2
@@ -591,6 +597,8 @@ async def test_format_memories_for_fake_tool_call():
     assert tool_msg["role"] == "tool"
     assert tool_msg["tool_call_id"] == tc["id"]
     assert "Python" in tool_msg["content"]
+    assert '"session_filtered": true' in tool_msg["content"]
+    assert '"persona_filtered": false' in tool_msg["content"]
     assert '"id": 101' in tool_msg["content"]
     assert '"id": 202' in tool_msg["content"]
     assert "用户喜欢Python编程" in tool_msg["content"]
@@ -667,6 +675,8 @@ async def test_handle_memory_recall_injection_fake_tool_call(
     # 验证 tool 消息
     assert tool_msg["role"] == "tool"
     assert tool_msg["tool_call_id"] == assistant_msg["tool_calls"][0]["id"]
+    assert '"session_filtered": true' in tool_msg["content"]
+    assert '"persona_filtered": true' in tool_msg["content"]
     assert '"id": 99' in tool_msg["content"]
     assert "用户喜欢吃火锅" in tool_msg["content"]
 

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -548,6 +548,7 @@ async def test_format_memories_for_fake_tool_call():
 
     memories = [
         {
+            "id": 101,
             "content": "用户喜欢Python编程",
             "score": 0.85,
             "metadata": {
@@ -560,6 +561,7 @@ async def test_format_memories_for_fake_tool_call():
             "timestamp": 1700000000,
         },
         {
+            "doc_id": 202,
             "content": "用户讨论过机器学习项目",
             "score": 0.72,
             "metadata": {"importance": 0.7},
@@ -589,6 +591,8 @@ async def test_format_memories_for_fake_tool_call():
     assert tool_msg["role"] == "tool"
     assert tool_msg["tool_call_id"] == tc["id"]
     assert "Python" in tool_msg["content"]
+    assert '"id": 101' in tool_msg["content"]
+    assert '"id": 202' in tool_msg["content"]
     assert "用户喜欢Python编程" in tool_msg["content"]
     assert "用户讨论过机器学习项目" in tool_msg["content"]
 
@@ -635,6 +639,7 @@ async def test_handle_memory_recall_injection_fake_tool_call(
         final_score=0.88,
         metadata={"importance": 0.9, "create_time": 1700000000},
     )
+    recalled.doc_id = 99
     memory_engine.search_memories = AsyncMock(return_value=[recalled])
 
     event = _make_event(group=False)
@@ -662,6 +667,7 @@ async def test_handle_memory_recall_injection_fake_tool_call(
     # 验证 tool 消息
     assert tool_msg["role"] == "tool"
     assert tool_msg["tool_call_id"] == assistant_msg["tool_calls"][0]["id"]
+    assert '"id": 99' in tool_msg["content"]
     assert "用户喜欢吃火锅" in tool_msg["content"]
 
     # prompt 和 system_prompt 不应被修改


### PR DESCRIPTION
### 变更摘要
新增 `recall_engine.injection_method = fake_tool_call` 注入策略，将长期记忆召回结果伪装成 OpenAI 风格的 `assistant(tool_calls) + tool(result)` 消息对注入到对话历史中，使 LLM 更自然地理解这是检索结果。

### 主要改动
- `core/utils/__init__.py`
  - 新增 `format_memories_for_fake_tool_call()`，把记忆列表格式化为伪造工具调用消息对。
- `core/event_handler.py`
  - `handle_memory_recall()` 增加 `fake_tool_call` 分支。
  - 新增 `_remove_fake_tool_call_from_context()`，在下次请求前自动清理历史中的伪造消息对，避免上下文堆积；通过 `fake_recall_` 前缀识别，不误删真实工具调用。
- `core/base/constants.py`
  - 新增 `FAKE_TOOL_CALL_NAME`（复用已注册的 `recall_long_term_memory`）和 `FAKE_TOOL_CALL_ID_PREFIX`。
- `core/base/config_validator.py` & `_conf_schema.json`
  - 将 `fake_tool_call` 纳入正式支持的注入方式，UI 自动显示该选项。
- `tests/`
  - 为 `fake_tool_call` 增加格式化、注入、清理、保护真实工具调用的单元测试。

### 兼容性
- **零破坏**：现有 `system_prompt` / `user_message_before` / `user_message_after` 三种注入方式保持默认行为不变。
- **安全隔离**：伪造消息使用 `fake_recall_` 前缀，清理逻辑严格匹配，不会影响真实 Agent 工具调用。

### 测试
```bash
python -m pytest tests/test_event_handler.py -q
# 22 passed, 1 warning
```

### 相关 Issue / 需求
无上游 issue，为功能增强 PR。