### PR TITLE
fix: Gemini 下 fake_tool_call 报错并自动降级

### DIFF
--- a/core/event_handler.py
+++ b/core/event_handler.py
@@ -122,6 +122,44 @@ class EventHandler:
         except Exception as e:
             logger.error(f"处理群聊全量消息时发生错误: {e}", exc_info=True)
 
+    def _resolve_injection_mode(self, configured_mode: str) -> str:
+        """根据当前 Provider 解析最终使用的注入模式。
+
+        Gemini 目前不完全兼容 fake_tool_call，自动降级到 system_prompt。
+        """
+        if configured_mode != "fake_tool_call":
+            return configured_mode
+
+        try:
+            provider = self.context.get_using_provider()
+            if provider:
+                config = getattr(provider, "provider_config", {})
+                provider_type = (
+                    config.get("type", "") if isinstance(config, dict) else ""
+                )
+                model_name = (
+                    provider.get_model()
+                    if hasattr(provider, "get_model")
+                    else ""
+                )
+
+                is_gemini = (
+                    provider_type == "googlegenai_chat_completion"
+                    or "gemini" in model_name.lower()
+                )
+
+                if is_gemini:
+                    logger.info(
+                        "[LivingMemory] fake_tool_call is not fully compatible with "
+                        f"Gemini (type={provider_type}, model={model_name}), "
+                        "fallback to system_prompt."
+                    )
+                    return "system_prompt"
+        except Exception:
+            pass
+
+        return configured_mode
+
     async def handle_memory_recall(self, event: AstrMessageEvent, req: ProviderRequest):
         """在 LLM 请求前，查询并注入长期记忆"""
         try:
@@ -228,10 +266,15 @@ class EventHandler:
                             f"内容={mem.content[:100]}..."
                         )
 
-                    # 根据配置选择注入方式
-                    injection_method = self.config_manager.get(
+                    # 根据配置选择注入方式（含 Provider 兼容降级）
+                    configured_method = self.config_manager.get(
                         "recall_engine.injection_method", "system_prompt"
                     )
+                    injection_method = self._resolve_injection_mode(configured_method)
+                    if injection_method != configured_method:
+                        logger.info(
+                            f"[{session_id}] 注入模式从 {configured_method} 降级为 {injection_method}"
+                        )
 
                     memory_str = format_memories_for_injection(memory_list)
 

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -547,6 +547,7 @@ def format_memories_for_fake_tool_call(
     tool_msg: dict[str, Any] = {
         "role": "tool",
         "tool_call_id": call_id,
+        "name": FAKE_TOOL_CALL_NAME,
         "content": tool_result_json,
     }
 

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -596,6 +596,7 @@ async def test_format_memories_for_fake_tool_call():
     # 验证 tool 消息格式
     assert tool_msg["role"] == "tool"
     assert tool_msg["tool_call_id"] == tc["id"]
+    assert tool_msg["name"] == "recall_long_term_memory"
     assert "Python" in tool_msg["content"]
     assert '"session_filtered": true' in tool_msg["content"]
     assert '"persona_filtered": false' in tool_msg["content"]
@@ -675,6 +676,7 @@ async def test_handle_memory_recall_injection_fake_tool_call(
     # 验证 tool 消息
     assert tool_msg["role"] == "tool"
     assert tool_msg["tool_call_id"] == assistant_msg["tool_calls"][0]["id"]
+    assert tool_msg["name"] == "recall_long_term_memory"
     assert '"session_filtered": true' in tool_msg["content"]
     assert '"persona_filtered": true' in tool_msg["content"]
     assert '"id": 99' in tool_msg["content"]
@@ -759,3 +761,159 @@ async def test_remove_fake_tool_call_preserves_real_tool_calls(handler):
     # 不应删除任何消息
     assert removed == 0
     assert len(req.contexts) == 2
+
+
+# ==================== fake_tool_call Gemini 降级测试 ====================
+
+
+def test_resolve_injection_mode_non_fake():
+    """非 fake_tool_call 模式应原样返回。"""
+    from astrbot_plugin_livingmemory.core.event_handler import EventHandler
+
+    h = EventHandler(
+        context=Mock(),
+        config_manager=Mock(),
+        memory_engine=Mock(),
+        memory_processor=Mock(),
+        conversation_manager=Mock(),
+    )
+    assert h._resolve_injection_mode("system_prompt") == "system_prompt"
+    assert h._resolve_injection_mode("user_message_before") == "user_message_before"
+
+
+def test_resolve_injection_mode_gemini_by_type():
+    """provider type 为 googlegenai_chat_completion 时应降级。"""
+    from astrbot_plugin_livingmemory.core.event_handler import EventHandler
+
+    gemini_provider = Mock()
+    gemini_provider.provider_config = {"type": "googlegenai_chat_completion"}
+    gemini_provider.get_model = Mock(return_value="gemini-2.5-pro")
+
+    context = Mock()
+    context.get_using_provider = Mock(return_value=gemini_provider)
+
+    h = EventHandler(
+        context=context,
+        config_manager=Mock(),
+        memory_engine=Mock(),
+        memory_processor=Mock(),
+        conversation_manager=Mock(),
+    )
+    assert h._resolve_injection_mode("fake_tool_call") == "system_prompt"
+
+
+def test_resolve_injection_mode_gemini_by_model_name():
+    """model 名包含 gemini 时应降级。"""
+    from astrbot_plugin_livingmemory.core.event_handler import EventHandler
+
+    gemini_provider = Mock()
+    gemini_provider.provider_config = {"type": "some_other_type"}
+    gemini_provider.get_model = Mock(return_value="gemini-1.5-flash")
+
+    context = Mock()
+    context.get_using_provider = Mock(return_value=gemini_provider)
+
+    h = EventHandler(
+        context=context,
+        config_manager=Mock(),
+        memory_engine=Mock(),
+        memory_processor=Mock(),
+        conversation_manager=Mock(),
+    )
+    assert h._resolve_injection_mode("fake_tool_call") == "system_prompt"
+
+
+def test_resolve_injection_mode_openai_unchanged():
+    """OpenAI 风格 provider 不应降级。"""
+    from astrbot_plugin_livingmemory.core.event_handler import EventHandler
+
+    openai_provider = Mock()
+    openai_provider.provider_config = {"type": "openai_chat_completion"}
+    openai_provider.get_model = Mock(return_value="gpt-4o")
+
+    context = Mock()
+    context.get_using_provider = Mock(return_value=openai_provider)
+
+    h = EventHandler(
+        context=context,
+        config_manager=Mock(),
+        memory_engine=Mock(),
+        memory_processor=Mock(),
+        conversation_manager=Mock(),
+    )
+    assert h._resolve_injection_mode("fake_tool_call") == "fake_tool_call"
+
+
+def test_resolve_injection_mode_no_provider():
+    """获取不到 provider 时不应降级。"""
+    from astrbot_plugin_livingmemory.core.event_handler import EventHandler
+
+    context = Mock()
+    context.get_using_provider = Mock(return_value=None)
+
+    h = EventHandler(
+        context=context,
+        config_manager=Mock(),
+        memory_engine=Mock(),
+        memory_processor=Mock(),
+        conversation_manager=Mock(),
+    )
+    assert h._resolve_injection_mode("fake_tool_call") == "fake_tool_call"
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_recall_fake_tool_call_fallback_on_gemini(
+    memory_engine,
+):
+    """Gemini 下配置 fake_tool_call 应自动降级为 system_prompt 注入。"""
+    from astrbot_plugin_livingmemory.core.base.config_manager import ConfigManager
+    from astrbot_plugin_livingmemory.core.event_handler import EventHandler
+
+    gemini_provider = Mock()
+    gemini_provider.provider_config = {"type": "googlegenai_chat_completion"}
+    gemini_provider.get_model = Mock(return_value="gemini-2.5-pro")
+
+    context = Mock()
+    context.get_using_provider = Mock(return_value=gemini_provider)
+
+    h = EventHandler(
+        context=context,
+        config_manager=ConfigManager(
+            {
+                "recall_engine": {
+                    "top_k": 3,
+                    "injection_method": "fake_tool_call",
+                },
+                "reflection_engine": {"summary_trigger_rounds": 1},
+                "session_manager": {"max_messages_per_session": 100},
+            }
+        ),
+        memory_engine=memory_engine,
+        memory_processor=Mock(),
+        conversation_manager=Mock(),
+    )
+    h.conversation_manager.add_message_from_event = AsyncMock()
+
+    recalled = Mock(
+        content="用户喜欢吃火锅",
+        final_score=0.88,
+        metadata={"importance": 0.9, "create_time": 1700000000},
+    )
+    recalled.doc_id = 99
+    memory_engine.search_memories = AsyncMock(return_value=[recalled])
+
+    event = _make_event(group=False)
+    req = _make_req("今天吃什么")
+
+    with patch(
+        "astrbot_plugin_livingmemory.core.event_handler.get_persona_id",
+        new_callable=AsyncMock,
+    ) as get_persona:
+        get_persona.return_value = "p1"
+        await h.handle_memory_recall(event, req)
+
+    # 降级后不应注入 fake_tool_call 消息，而应走 system_prompt
+    assert len(req.contexts) == 0
+    assert req.system_prompt != ""
+    assert "用户喜欢吃火锅" in req.system_prompt
+    assert req.prompt == "今天吃什么"


### PR DESCRIPTION
﻿## 背景
- 群友反馈在注入位置选择 `fake_tool_call` 时，Gemini 会抛 `EmptyModelOutputError`
- 这次原本是按 OpenAI 工具调用标准实现的，但伪造的 tool 消息结构没有完全对齐 Gemini 的要求
- AstrBot 的 Gemini provider 在处理 `role="tool"` 时会读取 `message.get("name", message["tool_call_id"])`
- 如果插件没有给 tool 消息写 `name`，就会把 `tool_call_id` 当成函数响应名
- 但 assistant 侧的调用名是 `recall_long_term_memory`，两边不一致会导致 Gemini 无法返回可用内容
- 同时 `fake_tool_call` 还没有在 Gemini 上充分验证，所以需要加自动降级兜底

## 变更
- 给 `format_memories_for_fake_tool_call` 生成的 tool 消息补上了 `name` 字段，和 `assistant.tool_calls[0].function.name` 保持一致
- 新增 `_resolve_injection_mode`，在注入前根据当前 provider 判断是否需要降级
- 当 `provider_config.type == "googlegenai_chat_completion"` 或模型名包含 `gemini` 时，自动把 `fake_tool_call` 降级为 `system_prompt`
- 在 `handle_memory_recall` 中先做模式解析，再执行注入，确保每次都走到正确路径
- 降级时会写一行 info 日志，方便排查

## 测试
- `tests/test_event_handler.py` 全量 28 个测试通过
- 新增 6 个测试覆盖 Gemini 降级场景
- provider type 为 `googlegenai_chat_completion` 时降级
- model 名包含 `gemini` 时降级
- OpenAI 风格 provider 保持 `fake_tool_call`
- 获取不到 provider 时不降级
- 集成测试验证 Gemini 场景实际走 `system_prompt` 注入
- 其余套件里有失败项，但都是环境问题
- `aiosqlite` 版本不兼容
- `jieba` 模块异常
- `main.py` 里已有的 `PlatformAdapterType` 拼写错误

## 说明
- 这个改动主要是修复 Gemini 下的兼容性问题，并给 `fake_tool_call` 增加降级兜底
