### PR TITLE
fix: 增加 DeepSeek V4 专用 fake tool call 兼容

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -120,7 +120,8 @@
           "user_message_before",
           "system_prompt",
           "user_message_after",
-          "fake_tool_call"
+          "fake_tool_call",
+          "fake_tool_call_deepseek_v4"
         ]
       },
       "auto_remove_injected": {

--- a/core/base/config_validator.py
+++ b/core/base/config_validator.py
@@ -46,7 +46,7 @@ class RecallEngineConfig(BaseModel):
     fallback_to_vector: bool = Field(default=True, description="是否启用向量检索回退")
     injection_method: str = Field(
         default="user_message_before",
-        description="记忆注入方式: system_prompt(系统提示), user_message_before(用户消息前), user_message_after(用户消息后), fake_tool_call(伪造工具调用)",
+        description="记忆注入方式: system_prompt(系统提示), user_message_before(用户消息前), user_message_after(用户消息后), fake_tool_call(伪造工具调用), fake_tool_call_deepseek_v4(DeepSeek V4兼容伪工具转录)",
     )
     auto_remove_injected: bool = Field(
         default=True, description="是否自动删除对话历史中已注入的记忆片段"

--- a/core/event_handler.py
+++ b/core/event_handler.py
@@ -20,6 +20,7 @@ from .processors.memory_processor import MemoryProcessor
 from .utils import (
     OperationContext,
     format_memories_for_fake_tool_call,
+    format_memories_for_fake_tool_call_deepseek_v4,
     format_memories_for_injection,
     get_persona_id,
 )
@@ -259,6 +260,22 @@ class EventHandler:
                             req.contexts.extend(fake_messages)
                             logger.info(
                                 f"[{session_id}] 成功以伪造工具调用方式注入 "
+                                f"{len(recalled_memories)} 条记忆"
+                            )
+                    elif injection_method == "fake_tool_call_deepseek_v4":
+                        fake_replay = format_memories_for_fake_tool_call_deepseek_v4(
+                            memory_list,
+                            query=actual_query,
+                            k=self.config_manager.get(
+                                "recall_engine.top_k", 5
+                            ),
+                            session_filtered=use_session_filtering,
+                            persona_filtered=use_persona_filtering,
+                        )
+                        if fake_replay:
+                            req.prompt = fake_replay + "\n\n" + (req.prompt or "")
+                            logger.info(
+                                f"[{session_id}] 成功以 DeepSeek V4 兼容伪工具转录方式注入 "
                                 f"{len(recalled_memories)} 条记忆"
                             )
                     else:

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -558,6 +558,60 @@ def format_memories_for_fake_tool_call(
     return [assistant_msg, tool_msg]
 
 
+def format_memories_for_fake_tool_call_deepseek_v4(
+    memories: list,
+    query: str,
+    k: int = 5,
+    session_filtered: bool = True,
+    persona_filtered: bool = True,
+) -> str:
+    """将伪工具调用转换成 DeepSeek V4 可接受的文本转录。"""
+    from ..base.constants import MEMORY_INJECTION_FOOTER, MEMORY_INJECTION_HEADER
+
+    fake_messages = format_memories_for_fake_tool_call(
+        memories=memories,
+        query=query,
+        k=k,
+        session_filtered=session_filtered,
+        persona_filtered=persona_filtered,
+    )
+    if not fake_messages:
+        return ""
+
+    assistant_msg = fake_messages[0] if len(fake_messages) > 0 else {}
+    tool_msg = fake_messages[1] if len(fake_messages) > 1 else {}
+    tool_calls = (
+        assistant_msg.get("tool_calls", [])
+        if isinstance(assistant_msg, dict)
+        else []
+    )
+    tool_call = tool_calls[0] if tool_calls else {}
+    function = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
+
+    function_name = (
+        function.get("name", "recall_long_term_memory")
+        if isinstance(function, dict)
+        else "recall_long_term_memory"
+    )
+    function_args = (
+        function.get("arguments", "{}") if isinstance(function, dict) else "{}"
+    )
+    tool_result = (
+        tool_msg.get("content", "{}")
+        if isinstance(tool_msg, dict)
+        else "{}"
+    )
+
+    return (
+        f"{MEMORY_INJECTION_HEADER}\n"
+        "[DeepSeekV4-FakeToolCall-Replay]\n"
+        f"assistant -> {function_name}({function_args})\n"
+        f"tool -> {tool_result}\n"
+        "[/DeepSeekV4-FakeToolCall-Replay]\n"
+        f"{MEMORY_INJECTION_FOOTER}"
+    )
+
+
 __all__ = [
     "StopwordsManager",
     "get_stopwords_manager",
@@ -573,4 +627,5 @@ __all__ = [
     "get_now_datetime_from_context",
     "format_memories_for_injection",
     "format_memories_for_fake_tool_call",
+    "format_memories_for_fake_tool_call_deepseek_v4",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ fastapi>=0.110.0
 uvicorn>=0.23.0
 pytz>=2021.3
 aiofiles>=23.0.0
+aiosqlite>=0.20.0


### PR DESCRIPTION
## 背景
DeepSeek V4 thinking 模式会校验历史对话中的 tool call 回传
插件当前的协议级 fake tool call 会把伪造的 assistant 和 tool 消息写入上下文
这会触发 DeepSeek 的 thinking 回传校验并导致 400 错误

## 改动
新增 `fake_tool_call_deepseek_v4` 注入方式
DeepSeek V4 场景不再把协议级 fake tool call 写入 `req.contexts`
改为生成带边界标记的文本转录并注入到 `req.prompt`
保留现有 `fake_tool_call` 行为不变
补充配置说明和可选项
同步补充 `aiosqlite` 运行依赖

## 测试
执行 `python -m compileall -f core\event_handler.py core\utils\__init__.py core\base\config_validator.py`
执行 `pytest`

## 测试结果
编译检查通过
全量测试未完全通过
当前失败主要集中在测试 stub 和环境兼容性
包含 `filter` 装饰器 stub 缺口 `aiosqlite` 测试上下文兼容问题 `jieba` 测试 stub 缺口