### PR TITLE
修复多个 open bug issue

### DIFF
--- a/core/managers/conversation_manager.py
+++ b/core/managers/conversation_manager.py
@@ -35,6 +35,8 @@ class ConversationManager:
     - AstrBot事件集成
     """
 
+    _UNKNOWN_SENDER_NAMES = {"", "unknown", "none", "null", "n/a", "na", "未知"}
+
     def __init__(
         self,
         store: ConversationStore,
@@ -101,11 +103,7 @@ class ConversationManager:
         if not sender_id:
             sender_id = session_id
 
-        # 尝试获取发送者昵称
-        if hasattr(event, "get_sender_name"):
-            sender_name = event.get_sender_name()
-        elif hasattr(event, "sender_name"):
-            sender_name = event.sender_name
+        sender_name = self._resolve_sender_name(event, sender_id)
 
         # Debug: 记录原始 message_obj.sender 信息
         if hasattr(event, "message_obj") and hasattr(event.message_obj, "sender"):
@@ -227,6 +225,88 @@ class ConversationManager:
             )
 
         return message
+
+    @classmethod
+    def _normalize_sender_name(cls, value) -> str | None:
+        """过滤平台占位昵称，保留可读名称。"""
+        if value is None:
+            return None
+        text = str(value).strip()
+        if text.lower() in cls._UNKNOWN_SENDER_NAMES:
+            return None
+        return text
+
+    @staticmethod
+    def _raw_get(obj, key: str):
+        if obj is None:
+            return None
+        if isinstance(obj, dict):
+            return obj.get(key)
+        return getattr(obj, key, None)
+
+    @classmethod
+    def _format_raw_user_name(cls, raw_user, sender_id: str | None) -> str | None:
+        username = cls._normalize_sender_name(cls._raw_get(raw_user, "username"))
+        if username:
+            return username
+
+        first_name = cls._normalize_sender_name(cls._raw_get(raw_user, "first_name"))
+        last_name = cls._normalize_sender_name(cls._raw_get(raw_user, "last_name"))
+        full_name = " ".join(part for part in (first_name, last_name) if part).strip()
+        if full_name:
+            return full_name
+
+        display_name = cls._normalize_sender_name(cls._raw_get(raw_user, "full_name"))
+        if display_name:
+            return display_name
+
+        raw_id = cls._normalize_sender_name(cls._raw_get(raw_user, "id"))
+        if raw_id:
+            return raw_id
+
+        return cls._normalize_sender_name(sender_id)
+
+    @classmethod
+    def _iter_raw_sender_candidates(cls, event):
+        message_obj = getattr(event, "message_obj", None)
+        raw_message = getattr(message_obj, "raw_message", None)
+        for source in (
+            raw_message,
+            cls._raw_get(raw_message, "message"),
+            cls._raw_get(raw_message, "effective_message"),
+            cls._raw_get(raw_message, "callback_query"),
+        ):
+            raw_user = cls._raw_get(source, "from_user")
+            if raw_user is not None:
+                yield raw_user
+        effective_user = cls._raw_get(raw_message, "effective_user")
+        if effective_user is not None:
+            yield effective_user
+
+    @classmethod
+    def _resolve_sender_name(cls, event, sender_id: str | None) -> str | None:
+        sender_name = None
+        if hasattr(event, "get_sender_name"):
+            sender_name = event.get_sender_name()
+        elif hasattr(event, "sender_name"):
+            sender_name = event.sender_name
+
+        normalized = cls._normalize_sender_name(sender_name)
+        if normalized:
+            return normalized
+
+        message_obj = getattr(event, "message_obj", None)
+        raw_sender = getattr(message_obj, "sender", None)
+        raw_nickname = cls._normalize_sender_name(cls._raw_get(raw_sender, "nickname"))
+        if raw_nickname:
+            return raw_nickname
+
+        for raw_user in cls._iter_raw_sender_candidates(event):
+            candidate = cls._format_raw_user_name(raw_user, sender_id)
+            if candidate:
+                return candidate
+
+        return cls._normalize_sender_name(sender_id)
 
     async def get_context(
         self,

--- a/core/plugin_initializer.py
+++ b/core/plugin_initializer.py
@@ -217,7 +217,7 @@ class PluginInitializer:
         # 初始化 Embedding Provider
         emb_id = self.config_manager.get("provider_settings.embedding_provider_id")
         if emb_id:
-            provider = self.context.get_provider_by_id(emb_id)
+            provider = self._get_provider_by_id(emb_id, silent=silent)
             if provider and isinstance(provider, EmbeddingProvider):
                 self.embedding_provider = provider
                 if not silent:
@@ -245,7 +245,7 @@ class PluginInitializer:
         self.llm_provider = None
         llm_id = self.config_manager.get("provider_settings.llm_provider_id")
         if llm_id:
-            provider = self.context.get_provider_by_id(llm_id)
+            provider = self._get_provider_by_id(llm_id, silent=silent)
             if provider and isinstance(provider, Provider):
                 self.llm_provider = provider
                 if not silent:
@@ -257,6 +257,9 @@ class PluginInitializer:
 
         if not self.llm_provider:
             try:
+                if silent and not self.context.get_all_providers():
+                    self.llm_provider = None
+                    return
                 default_provider = self.context.get_using_provider()
                 if default_provider and not isinstance(default_provider, Provider):
                     if not silent:
@@ -272,6 +275,18 @@ class PluginInitializer:
                 if not silent:
                     logger.debug(f"获取默认 LLM Provider 失败: {e}")
                 self.llm_provider = None
+
+    def _get_provider_by_id(self, provider_id: str, *, silent: bool):
+        """静默检查阶段绕过会打印 warning 的 AstrBot 查询接口。"""
+        if not provider_id:
+            return None
+        if not silent:
+            return self.context.get_provider_by_id(provider_id)
+        provider_manager = getattr(self.context, "provider_manager", None)
+        inst_map = getattr(provider_manager, "inst_map", None)
+        if isinstance(inst_map, dict):
+            return inst_map.get(provider_id)
+        return None
 
     async def _complete_initialization(self):
         """完成完整的初始化流程"""

--- a/core/processors/text_processor.py
+++ b/core/processors/text_processor.py
@@ -5,6 +5,7 @@
 
 import re
 import string
+import warnings
 from collections import Counter
 from pathlib import Path
 
@@ -14,6 +15,7 @@ try:
     JIEBA_AVAILABLE = True
 except ImportError:
     JIEBA_AVAILABLE = False
+JIEBA_RUNTIME_DISABLED = False
 
 
 class TextProcessor:
@@ -294,8 +296,6 @@ class TextProcessor:
 
         # 检查 jieba 是否可用
         if not JIEBA_AVAILABLE:
-            import warnings
-
             warnings.warn(
                 "jieba 库未安装,中文分词将受限。建议安装: pip install jieba",
                 UserWarning,
@@ -445,15 +445,21 @@ class TextProcessor:
             >>> processor.add_custom_words(["LivingMemory", "AstrBot"])
         """
         if not JIEBA_AVAILABLE:
-            import warnings
-
             warnings.warn("jieba 未安装,无法添加自定义词汇", UserWarning)
             return
 
         self.custom_words.update(words)
 
         for word in words:
-            jieba.add_word(word)
+            try:
+                jieba.add_word(word)
+            except Exception as e:
+                warnings.warn(
+                    f"jieba 初始化失败，已跳过自定义词加载并降级分词: {e}",
+                    UserWarning,
+                )
+                self._disable_jieba_runtime()
+                return
 
     def add_stopwords(self, words: list[str]):
         """
@@ -565,13 +571,49 @@ class TextProcessor:
         # 检查是否包含中文
         has_chinese = any("\u4e00" <= char <= "\u9fff" for char in text)
 
-        if has_chinese and JIEBA_AVAILABLE:
+        if has_chinese and JIEBA_AVAILABLE and not JIEBA_RUNTIME_DISABLED:
             # 使用 jieba 分词 (搜索模式,适合检索)
-            tokens = list(jieba.cut_for_search(text))
+            try:
+                tokens = list(jieba.cut_for_search(text))
+            except Exception as e:
+                warnings.warn(
+                    f"jieba 分词初始化失败，已降级为内置中文分词: {e}",
+                    UserWarning,
+                )
+                self._disable_jieba_runtime()
+                tokens = self._fallback_segment(text)
         else:
             # 按空格分词 (适用于英文或 jieba 不可用时)
-            tokens = text.split()
+            tokens = self._fallback_segment(text)
 
+        return tokens
+
+    @staticmethod
+    def _disable_jieba_runtime() -> None:
+        global JIEBA_RUNTIME_DISABLED
+        JIEBA_RUNTIME_DISABLED = True
+
+    @staticmethod
+    def _fallback_segment(text: str) -> list[str]:
+        tokens: list[str] = []
+        buffer: list[str] = []
+
+        def flush_buffer():
+            if buffer:
+                tokens.append("".join(buffer))
+                buffer.clear()
+
+        for char in text:
+            if "\u4e00" <= char <= "\u9fff":
+                flush_buffer()
+                tokens.append(char)
+                continue
+            if char.isspace():
+                flush_buffer()
+                continue
+            buffer.append(char)
+
+        flush_buffer()
         return tokens
 
     def is_stopword(self, word: str) -> bool:

--- a/main.py
+++ b/main.py
@@ -55,6 +55,7 @@ class LivingMemoryPlugin(Star):
         self._background_tasks: set[asyncio.Task] = set()
         self._component_init_lock = asyncio.Lock()
         self._llm_tools_registered = False
+        self._terminating = False
 
         # 启动非阻塞的初始化任务
         self._create_tracked_task(self._initialize_plugin())
@@ -80,10 +81,14 @@ class LivingMemoryPlugin(Star):
 
     async def _ensure_runtime_components(self) -> bool:
         """确保运行期组件（事件/命令处理器、WebUI）已就绪"""
+        if self._terminating:
+            return False
         if not self.initializer.is_initialized:
             return False
 
         async with self._component_init_lock:
+            if self._terminating:
+                return False
             # 检查必要组件是否初始化成功
             if not all(
                 [
@@ -159,6 +164,8 @@ class LivingMemoryPlugin(Star):
 
     async def _start_webui(self):
         """根据配置启动 WebUI 控制台"""
+        if self._terminating:
+            return
         webui_config = self.config_manager.webui_settings
         if not webui_config.get("enabled"):
             return
@@ -491,6 +498,7 @@ class LivingMemoryPlugin(Star):
     async def terminate(self):
         """插件停止时的清理逻辑"""
         logger.info("LivingMemory 插件正在停止...")
+        self._terminating = True
 
         # 取消所有后台任务
         if self._background_tasks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 faiss-cpu>=1.7.0
 networkx>=3.0
 jieba>=0.42.1
-fastapi>=0.110.0
+fastapi>=0.115.6
 uvicorn>=0.23.0
 pytz>=2021.3
 aiofiles>=23.0.0

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -3,6 +3,7 @@ Tests for ConversationManager behaviors.
 """
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from astrbot_plugin_livingmemory.core.managers.conversation_manager import (
@@ -31,6 +32,40 @@ class _DummyEvent:
 
     def get_platform_name(self):
         return "test"
+
+
+class _DummyTelegramEvent(_DummyEvent):
+    def __init__(
+        self,
+        session_id: str,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        user_id: int = 12345,
+    ):
+        super().__init__(session_id, group=False)
+        self.sender_id = str(user_id)
+        raw_user = SimpleNamespace(
+            id=user_id,
+            username=None,
+            first_name=first_name,
+            last_name=last_name,
+        )
+        self.message_obj = SimpleNamespace(
+            sender=SimpleNamespace(user_id=str(user_id), nickname="Unknown"),
+            raw_message=SimpleNamespace(
+                message=SimpleNamespace(from_user=raw_user),
+                effective_user=raw_user,
+            ),
+        )
+
+    def get_sender_id(self):
+        return self.sender_id
+
+    def get_sender_name(self):
+        return "Unknown"
+
+    def get_platform_name(self):
+        return "telegram"
 
 
 @pytest.mark.asyncio
@@ -85,5 +120,46 @@ async def test_conversation_manager_range_and_metadata(tmp_path: Path):
 
     await manager.clear_session("test:private:s2")
     assert await store.get_message_count("test:private:s2") == 0
+
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_conversation_manager_resolves_telegram_name_without_username(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "telegram.db"
+    store = ConversationStore(str(db_path))
+    await store.initialize()
+    manager = ConversationManager(store=store, max_cache_size=2, context_window_size=10)
+
+    event = _DummyTelegramEvent(
+        "telegram:private:s3",
+        first_name="Alice",
+        last_name="Lee",
+        user_id=67890,
+    )
+    message = await manager.add_message_from_event(event, role="user", content="hello")
+
+    assert message.sender_id == "67890"
+    assert message.sender_name == "Alice Lee"
+
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_conversation_manager_falls_back_to_sender_id_for_unknown_name(
+    tmp_path: Path,
+):
+    db_path = tmp_path / "telegram-id.db"
+    store = ConversationStore(str(db_path))
+    await store.initialize()
+    manager = ConversationManager(store=store, max_cache_size=2, context_window_size=10)
+
+    event = _DummyTelegramEvent("telegram:private:s4", user_id=24680)
+    message = await manager.add_message_from_event(event, role="user", content="hello")
+
+    assert message.sender_id == "24680"
+    assert message.sender_name == "24680"
 
     await store.close()

--- a/tests/test_text_processor.py
+++ b/tests/test_text_processor.py
@@ -4,8 +4,8 @@ Tests for TextProcessor behaviors.
 
 from pathlib import Path
 
-import pytest
 import astrbot_plugin_livingmemory.core.processors.text_processor as text_processor_mod
+import pytest
 from astrbot_plugin_livingmemory.core.processors.text_processor import TextProcessor
 
 

--- a/tests/test_text_processor.py
+++ b/tests/test_text_processor.py
@@ -5,6 +5,7 @@ Tests for TextProcessor behaviors.
 from pathlib import Path
 
 import pytest
+import astrbot_plugin_livingmemory.core.processors.text_processor as text_processor_mod
 from astrbot_plugin_livingmemory.core.processors.text_processor import TextProcessor
 
 
@@ -51,3 +52,22 @@ def test_preprocess_for_bm25_and_word_freq():
     freq = processor.get_word_freq(["我 爱 编程", "编程 很 有趣"])
     assert isinstance(freq, dict)
     assert len(freq) > 0
+
+
+def test_tokenize_falls_back_when_jieba_runtime_fails(monkeypatch):
+    class BrokenJieba:
+        @staticmethod
+        def cut_for_search(text):
+            raise AttributeError("module 'pkg_resources' has no attribute 'resource_stream'")
+
+    monkeypatch.setattr(text_processor_mod, "JIEBA_AVAILABLE", True)
+    monkeypatch.setattr(text_processor_mod, "JIEBA_RUNTIME_DISABLED", False)
+    monkeypatch.setattr(text_processor_mod, "jieba", BrokenJieba)
+
+    processor = TextProcessor()
+    with pytest.warns(UserWarning, match="jieba 分词初始化失败"):
+        tokens = processor.tokenize("编程快乐")
+
+    assert tokens
+    assert "编" in tokens
+    assert text_processor_mod.JIEBA_RUNTIME_DISABLED is True

--- a/tests/test_webui_server.py
+++ b/tests/test_webui_server.py
@@ -1,0 +1,40 @@
+"""Tests for WebUIServer lifecycle behavior."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import astrbot_plugin_livingmemory.webui.server as webui_server_mod
+from astrbot_plugin_livingmemory.webui.server import WebUIServer
+
+
+@pytest.mark.asyncio
+async def test_webui_start_failure_does_not_raise_system_exit(monkeypatch):
+    class FailingServer:
+        started = False
+        should_exit = False
+
+        def __init__(self, config):
+            self.config = config
+
+        async def serve(self):
+            raise SystemExit(1)
+
+    monkeypatch.setattr(webui_server_mod.uvicorn, "Server", FailingServer)
+
+    server = WebUIServer(
+        memory_engine=SimpleNamespace(config={}),
+        config={
+            "host": "127.0.0.1",
+            "port": 18081,
+            "access_password": "test-password",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="WebUI 启动失败"):
+        await server.start()
+
+    assert server._server is None
+    assert server._server_task is None
+    assert server._cleanup_task is None
+

--- a/tests/test_webui_server.py
+++ b/tests/test_webui_server.py
@@ -2,9 +2,8 @@
 
 from types import SimpleNamespace
 
-import pytest
-
 import astrbot_plugin_livingmemory.webui.server as webui_server_mod
+import pytest
 from astrbot_plugin_livingmemory.webui.server import WebUIServer
 
 
@@ -37,4 +36,3 @@ async def test_webui_start_failure_does_not_raise_system_exit(monkeypatch):
     assert server._server is None
     assert server._server_task is None
     assert server._cleanup_task is None
-

--- a/webui/server.py
+++ b/webui/server.py
@@ -118,6 +118,8 @@ class WebUIServer:
         self._server: uvicorn.Server | None = None
         self._server_task: asyncio.Task | None = None
         self._cleanup_task: asyncio.Task | None = None
+        self._lifecycle_lock = asyncio.Lock()
+        self._server_error: BaseException | None = None
 
         self._app = FastAPI(title="LivingMemory WebUI", version="2.0.0")
         self._setup_routes()
@@ -128,38 +130,70 @@ class WebUIServer:
 
     async def start(self):
         """启动WebUI服务"""
-        if self._server_task and not self._server_task.done():
-            logger.warning("WebUI 服务已经在运行")
-            return
-
-        config = uvicorn.Config(
-            app=self._app,
-            host=self.host,
-            port=self.port,
-            log_level="info",
-            loop="asyncio",
-            lifespan="on",
-        )
-        self._server = uvicorn.Server(config)
-        self._server_task = asyncio.create_task(self._server.serve())
-
-        # 启动定期清理任务
-        self._cleanup_task = asyncio.create_task(self._periodic_cleanup())
-
-        # 等待服务启动
-        for _ in range(50):
-            if getattr(self._server, "started", False):
-                logger.info(f"WebUI 已启动: http://{self.host}:{self.port}")
+        async with self._lifecycle_lock:
+            if self._server_task and not self._server_task.done():
+                logger.warning("WebUI 服务已经在运行")
                 return
-            if self._server_task.done():
-                error = self._server_task.exception()
-                raise RuntimeError(f"WebUI 启动失败: {error}") from error
-            await asyncio.sleep(0.1)
 
-        logger.warning("WebUI 启动耗时较长，仍在后台启动中")
+            self._server_error = None
+            config = uvicorn.Config(
+                app=self._app,
+                host=self.host,
+                port=self.port,
+                log_level="info",
+                loop="asyncio",
+                lifespan="on",
+            )
+            self._server = uvicorn.Server(config)
+            self._server_task = asyncio.create_task(self._serve_safely())
+
+            # 启动定期清理任务
+            self._cleanup_task = asyncio.create_task(self._periodic_cleanup())
+
+            try:
+                # 等待服务启动
+                for _ in range(50):
+                    if getattr(self._server, "started", False):
+                        logger.info(f"WebUI 已启动: http://{self.host}:{self.port}")
+                        return
+                    if self._server_error is not None:
+                        raise RuntimeError(
+                            f"WebUI 启动失败: {self._server_error}"
+                        ) from self._server_error
+                    if self._server_task.done():
+                        raise RuntimeError("WebUI 启动失败，服务任务已提前结束")
+                    await asyncio.sleep(0.1)
+
+                logger.warning("WebUI 启动耗时较长，仍在后台启动中")
+            except asyncio.CancelledError:
+                await self._stop_locked()
+                raise
+            except Exception:
+                await self._stop_locked()
+                raise
 
     async def stop(self):
         """停止WebUI服务"""
+        async with self._lifecycle_lock:
+            await self._stop_locked()
+
+    async def _serve_safely(self):
+        try:
+            if self._server:
+                await self._server.serve()
+        except asyncio.CancelledError:
+            raise
+        except SystemExit as e:
+            self._server_error = e
+            logger.error(
+                f"WebUI 启动失败，监听地址可能已被占用: {self.host}:{self.port}。"
+                "如果刚重载插件，通常是旧实例端口尚未释放。"
+            )
+        except Exception as e:
+            self._server_error = e
+            logger.error(f"WebUI 服务异常退出: {e}", exc_info=True)
+
+    async def _stop_locked(self):
         # 停止定期清理任务
         if self._cleanup_task and not self._cleanup_task.done():
             self._cleanup_task.cancel()
@@ -171,7 +205,12 @@ class WebUIServer:
         if self._server:
             self._server.should_exit = True
         if self._server_task:
-            await self._server_task
+            try:
+                await self._server_task
+            except asyncio.CancelledError:
+                pass
+            except BaseException as e:
+                logger.debug(f"WebUI 服务任务结束时返回异常: {e}")
         self._server = None
         self._server_task = None
         self._cleanup_task = None


### PR DESCRIPTION
修复当前 open issue 中可直接落代码处理的 bug。

修复内容：
- 修复 #111：Telegram 私聊未设置 username 时，将 Unknown 回退为 first_name/last_name/full_name/id。
- 修复 #81：WebUI 重载或端口占用时捕获 uvicorn SystemExit，并在启动失败时幂等回滚。
- 修复 #82/#83：jieba 在 Python 3.12+ 运行期初始化失败时，自动降级到内置分词。
- 修复 #100：Provider 尚未初始化时，静默检查不再调用会打印 warning 的 AstrBot 查询接口。
- 修复 #91：提升 FastAPI 下限以兼容 Pydantic 2.12。

验证：
- uv run pytest（210 passed, 7 warnings）