### PR TITLE
fix: 补全 Telegram 无 username 时的 Unknown 回退过滤

### DIFF
--- a/core/managers/conversation_manager.py
+++ b/core/managers/conversation_manager.py
@@ -35,7 +35,7 @@ class ConversationManager:
     - AstrBot事件集成
     """
 
-    _UNKNOWN_SENDER_NAMES = {"", "unknown", "none", "null", "n/a", "na", "未知"}
+    _UNKNOWN_SENDER_NAMES = {"", "unknown", "Unknown", "none", "null", "n/a", "na", "user", "user_", "tg", "未知"}
 
     def __init__(
         self,


### PR DESCRIPTION
### 问题

Telegram 适配器在用户未设置 @username 时，会将发送者昵称显式填写为 `"Unknown"`（首字母大写），而插件的 `_UNKNOWN_SENDER_NAMES` 集合只包含小写 `"unknown"`，导致 PR #113 设计的 raw_user 回退链无法触发，记忆里出现大量僵尸 `"Unknown"` 记录。

### 修复

将 `"Unknown"`（以及 `"user"`、`"user_"`、`"tg"` 等 Telegram 常见占位名）加入 `_UNKNOWN_SENDER_NAMES` 集合，确保无 username 的消息能正常进入 raw_user 回退逻辑。

### 测试

- 无 username 时，`event.get_sender_name()` 返回 `"Unknown"` → 被过滤为无效
- 走 raw_message.from_user 回退链 → 成功拼接 first_name + last_name