### PR TITLE
fix: 修复 WebUI 生命周期与历史消息批量清理

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -79,6 +79,18 @@
         "hint": "传给 LLM 的最大历史消息条数。越大上下文越丰富，但消耗 token 越多。建议 20-100。",
         "type": "int",
         "default": 50
+      },
+      "max_messages_per_session": {
+        "description": "单会话最大历史消息数",
+        "hint": "数据库中每个会话保留的历史消息上限。超过后只会删除已经完成总结的最旧消息，避免丢失未总结上下文。",
+        "type": "int",
+        "default": 1000
+      },
+      "cleanup_batch_size": {
+        "description": "历史消息批量清理数量",
+        "hint": "会话历史超过上限后，每次至少尝试删除的旧已总结消息数量。值过小会导致超限后每轮只删少量消息。",
+        "type": "int",
+        "default": 50
       }
     }
   },

--- a/core/base/config_validator.py
+++ b/core/base/config_validator.py
@@ -31,6 +31,12 @@ class SessionManagerConfig(BaseModel):
         le=10000,
         description="单会话最大消息数量(超出后自动删除旧消息)",
     )
+    cleanup_batch_size: int = Field(
+        default=50,
+        ge=1,
+        le=1000,
+        description="历史消息超过上限后每次批量删除的旧已总结消息数",
+    )
 
 
 class RecallEngineConfig(BaseModel):

--- a/core/event_handler.py
+++ b/core/event_handler.py
@@ -1150,6 +1150,14 @@ class EventHandler:
         max_messages = self.config_manager.get(
             "session_manager.max_messages_per_session", 1000
         )
+        cleanup_batch_size = self.config_manager.get(
+            "session_manager.cleanup_batch_size", 50
+        )
+        try:
+            cleanup_batch_size = int(cleanup_batch_size)
+        except (TypeError, ValueError):
+            cleanup_batch_size = 50
+        cleanup_batch_size = max(1, cleanup_batch_size)
 
         if (
             not self.conversation_manager.store
@@ -1175,23 +1183,26 @@ class EventHandler:
                 )
             )
 
-            # 计算需要删除的数量
-            to_delete = actual_count - max_messages
+            # 计算需要删除的数量；超过上限时按批量清理，减少每轮只删 1 条的抖动。
+            overflow_count = actual_count - max_messages
+            target_delete = max(overflow_count, cleanup_batch_size)
 
             # 只能删除已总结的消息，不能删除未总结的
-            safe_to_delete = min(to_delete, last_summarized_index)
+            safe_to_delete = min(target_delete, last_summarized_index)
 
             if safe_to_delete <= 0:
                 logger.debug(
                     f"[{session_id}] 无可删除消息: "
-                    f"需删除={to_delete}, 已总结={last_summarized_index}"
+                    f"溢出={overflow_count}, 批量={cleanup_batch_size}, "
+                    f"目标删除={target_delete}, 已总结={last_summarized_index}"
                 )
                 return
 
             logger.info(
                 f"[{session_id}] 开始清理已总结消息: "
                 f"总数={actual_count}, 上限={max_messages}, "
-                f"需删除={to_delete}, 已总结={last_summarized_index}, "
+                f"溢出={overflow_count}, 批量={cleanup_batch_size}, "
+                f"目标删除={target_delete}, 已总结={last_summarized_index}, "
                 f"实际删除={safe_to_delete}"
             )
 

--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ class LivingMemoryPlugin(Star):
         # 后台任务跟踪集合
         self._background_tasks: set[asyncio.Task] = set()
         self._component_init_lock = asyncio.Lock()
+        self._webui_lifecycle_lock = asyncio.Lock()
         self._llm_tools_registered = False
         self._terminating = False
 
@@ -191,47 +192,59 @@ class LivingMemoryPlugin(Star):
 
     async def _start_webui(self):
         """根据配置启动 WebUI 控制台"""
-        if self._terminating:
-            return
-        webui_config = self.config_manager.webui_settings
-        if not webui_config.get("enabled"):
-            return
-        if self.webui_server:
-            return
+        async with self._webui_lifecycle_lock:
+            if self._terminating:
+                return
+            webui_config = self.config_manager.webui_settings
+            if not webui_config.get("enabled"):
+                return
+            if self.webui_server:
+                return
 
-        try:
-            self.webui_server = WebUIServer(
-                memory_engine=self.initializer.memory_engine,
-                config=webui_config,
-                conversation_manager=self.initializer.conversation_manager,
-                index_validator=self.initializer.index_validator,
-            )
+            server: WebUIServer | None = None
+            try:
+                server = WebUIServer(
+                    memory_engine=self.initializer.memory_engine,
+                    config=webui_config,
+                    conversation_manager=self.initializer.conversation_manager,
+                    index_validator=self.initializer.index_validator,
+                )
+                self.webui_server = server
 
-            await self.webui_server.start()
-            if self.command_handler:
-                self.command_handler.webui_server = self.webui_server
+                await server.start()
+                if self.command_handler:
+                    self.command_handler.webui_server = server
 
-            logger.info(
-                f"WebUI started at: http://{webui_config.get('host', '127.0.0.1')}:{webui_config.get('port', 8080)}"
-            )
-        except Exception as e:
-            logger.error(f"启动 WebUI 控制台失败: {e}", exc_info=True)
-            self.webui_server = None
-            if self.command_handler:
-                self.command_handler.webui_server = None
+                logger.info(
+                    f"WebUI started at: http://{webui_config.get('host', '127.0.0.1')}:{webui_config.get('port', 8080)}"
+                )
+            except Exception as e:
+                logger.error(f"启动 WebUI 控制台失败: {e}", exc_info=True)
+                if server:
+                    try:
+                        await server.stop()
+                    except Exception as stop_error:
+                        logger.warning(
+                            f"回滚 WebUI 启动失败状态时出现异常: {stop_error}",
+                            exc_info=True,
+                        )
+                self.webui_server = None
+                if self.command_handler:
+                    self.command_handler.webui_server = None
 
     async def _stop_webui(self):
         """停止 WebUI 控制台"""
-        if not self.webui_server:
-            return
-        try:
-            await self.webui_server.stop()
-        except Exception as e:
-            logger.warning(f"停止 WebUI 控制台时出现异常: {e}", exc_info=True)
-        finally:
-            self.webui_server = None
-            if self.command_handler:
-                self.command_handler.webui_server = None
+        async with self._webui_lifecycle_lock:
+            if not self.webui_server:
+                return
+            try:
+                await self.webui_server.stop()
+            except Exception as e:
+                logger.warning(f"停止 WebUI 控制台时出现异常: {e}", exc_info=True)
+            finally:
+                self.webui_server = None
+                if self.command_handler:
+                    self.command_handler.webui_server = None
 
     def _get_initialization_status_message(self) -> str:
         """获取初始化状态的用户友好消息"""
@@ -527,6 +540,9 @@ class LivingMemoryPlugin(Star):
         logger.info("LivingMemory 插件正在停止...")
         self._terminating = True
 
+        # 先释放 WebUI 端口，避免插件热重载时新旧实例抢占同一监听地址。
+        await self._stop_webui()
+
         # 取消所有后台任务
         if self._background_tasks:
             logger.info(f"正在取消 {len(self._background_tasks)} 个后台任务...")
@@ -542,9 +558,6 @@ class LivingMemoryPlugin(Star):
         # 通知EventHandler停止（如果有正在运行的存储任务）
         if self.event_handler:
             await self.event_handler.shutdown()
-
-        # 停止 WebUI
-        await self._stop_webui()
 
         # 停止衰减调度器
         await self.initializer.stop_scheduler()

--- a/tests/integration/test_plugin_lifecycle_integration.py
+++ b/tests/integration/test_plugin_lifecycle_integration.py
@@ -161,6 +161,74 @@ async def test_webui_start_stop_updates_command_handler(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_webui_start_failure_rolls_back_server(monkeypatch, tmp_path):
+    class _FailingWebUIServer:
+        def __init__(
+            self,
+            memory_engine,
+            config,
+            conversation_manager=None,
+            index_validator=None,
+        ):
+            del memory_engine, config, conversation_manager, index_validator
+            self.stop = AsyncMock()
+
+        async def start(self):
+            raise RuntimeError("bind failed")
+
+    plugin = await _build_plugin(
+        monkeypatch,
+        tmp_path,
+        config={
+            "webui_settings": {
+                "enabled": True,
+                "host": "127.0.0.1",
+                "port": 6186,
+                "access_password": "test-password",
+            }
+        },
+    )
+    monkeypatch.setattr(plugin_main, "WebUIServer", _FailingWebUIServer)
+
+    plugin.initializer.memory_engine = SimpleNamespace(close=AsyncMock())
+    plugin.initializer.conversation_manager = SimpleNamespace(store=None)
+    plugin.initializer.index_validator = object()
+    plugin.command_handler = SimpleNamespace(webui_server=object())
+
+    await plugin._start_webui()
+
+    assert plugin.webui_server is None
+    assert plugin.command_handler.webui_server is None
+
+    await plugin.terminate()
+
+
+@pytest.mark.asyncio
+async def test_terminate_stops_webui_before_background_tasks(monkeypatch, tmp_path):
+    plugin = await _build_plugin(monkeypatch, tmp_path)
+    order = []
+
+    async def _stop_webui():
+        order.append("webui")
+
+    async def _running_task():
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            order.append("task")
+            raise
+
+    plugin._stop_webui = _stop_webui
+    running_task = plugin._create_tracked_task(_running_task())
+    await asyncio.sleep(0)
+
+    await plugin.terminate()
+
+    assert running_task.cancelled() or running_task.done()
+    assert order[:2] == ["webui", "task"]
+
+
+@pytest.mark.asyncio
 async def test_terminate_cleans_background_tasks_and_resources(monkeypatch, tmp_path):
     plugin = await _build_plugin(monkeypatch, tmp_path)
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -16,6 +16,8 @@ def test_config_manager_loads_defaults() -> None:
     assert manager.get("recall_engine.top_k") == 5
     assert manager.get("fusion_strategy.rrf_k") == 60
     assert manager.get("session_manager.max_sessions") == 100
+    assert manager.get("session_manager.max_messages_per_session") == 1000
+    assert manager.get("session_manager.cleanup_batch_size") == 50
     assert manager.get("reflection_engine.save_original_conversation") is None
 
 

--- a/tests/test_event_handler.py
+++ b/tests/test_event_handler.py
@@ -184,6 +184,51 @@ async def test_handle_all_group_messages_and_limit_cleanup(
 
 
 @pytest.mark.asyncio
+async def test_enforce_message_limit_uses_cleanup_batch_size(
+    memory_engine, memory_processor, conversation_manager
+):
+    handler = EventHandler(
+        context=Mock(),
+        config_manager=ConfigManager(
+            {
+                "recall_engine": {"top_k": 3, "injection_method": "system_prompt"},
+                "reflection_engine": {"summary_trigger_rounds": 1},
+                "session_manager": {
+                    "max_messages_per_session": 100,
+                    "cleanup_batch_size": 20,
+                },
+            }
+        ),
+        memory_engine=memory_engine,
+        memory_processor=memory_processor,
+        conversation_manager=conversation_manager,
+    )
+
+    count_results = [101, 81]
+
+    async def _get_message_count(_session_id):
+        return count_results.pop(0)
+
+    conversation_manager.store.get_message_count = AsyncMock(
+        side_effect=_get_message_count
+    )
+    conversation_manager.get_session_metadata = AsyncMock(return_value=80)
+    cursor = Mock(rowcount=20)
+    conversation_manager.store.connection.execute = AsyncMock(return_value=cursor)
+
+    await handler._enforce_message_limit("test:private:sid-1")
+
+    delete_call = conversation_manager.store.connection.execute.await_args_list[0]
+    assert delete_call.args[1] == ("test:private:sid-1", 20)
+    conversation_manager.update_session_metadata.assert_awaited_with(
+        "test:private:sid-1", "last_summarized_index", 60
+    )
+    conversation_manager.invalidate_cache.assert_awaited_once_with(
+        "test:private:sid-1"
+    )
+
+
+@pytest.mark.asyncio
 async def test_handle_all_group_messages_skips_bot_own_messages(
     handler, conversation_manager
 ):

--- a/tests/test_webui_server.py
+++ b/tests/test_webui_server.py
@@ -1,5 +1,6 @@
 """Tests for WebUIServer lifecycle behavior."""
 
+import asyncio
 from types import SimpleNamespace
 
 import astrbot_plugin_livingmemory.webui.server as webui_server_mod
@@ -36,3 +37,36 @@ async def test_webui_start_failure_does_not_raise_system_exit(monkeypatch):
     assert server._server is None
     assert server._server_task is None
     assert server._cleanup_task is None
+
+
+@pytest.mark.asyncio
+async def test_webui_stop_cancels_server_task_after_timeout(monkeypatch):
+    class HangingServer:
+        started = True
+        should_exit = False
+
+        def __init__(self, config):
+            self.config = config
+
+        async def serve(self):
+            await asyncio.sleep(3600)
+
+    monkeypatch.setattr(webui_server_mod.uvicorn, "Server", HangingServer)
+
+    server = WebUIServer(
+        memory_engine=SimpleNamespace(config={}),
+        config={
+            "host": "127.0.0.1",
+            "port": 18082,
+            "access_password": "test-password",
+            "shutdown_timeout": 0.01,
+        },
+    )
+    await server.start()
+
+    await server.stop()
+
+    assert server._server is None
+    assert server._server_task is None
+    assert server._cleanup_task is None
+    assert server._server_error is None

--- a/webui/server.py
+++ b/webui/server.py
@@ -120,6 +120,7 @@ class WebUIServer:
         self._cleanup_task: asyncio.Task | None = None
         self._lifecycle_lock = asyncio.Lock()
         self._server_error: BaseException | None = None
+        self._shutdown_timeout = float(config.get("shutdown_timeout", 5.0))
 
         self._app = FastAPI(title="LivingMemory WebUI", version="2.2.11")
         self._setup_routes()
@@ -206,7 +207,16 @@ class WebUIServer:
             self._server.should_exit = True
         if self._server_task:
             try:
-                await self._server_task
+                await asyncio.wait_for(self._server_task, self._shutdown_timeout)
+            except TimeoutError:
+                logger.warning(
+                    f"WebUI 停止超时，强制取消服务任务: {self.host}:{self.port}"
+                )
+                self._server_task.cancel()
+                try:
+                    await self._server_task
+                except asyncio.CancelledError:
+                    pass
             except asyncio.CancelledError:
                 pass
             except BaseException as e:
@@ -214,6 +224,7 @@ class WebUIServer:
         self._server = None
         self._server_task = None
         self._cleanup_task = None
+        self._server_error = None
         logger.info("WebUI 已停止")
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## 变更内容
- 串行化 WebUI 启动/停止流程，终止插件时优先释放 WebUI 端口
- WebUI 服务停止增加超时与强制取消，避免热重载时旧服务卡住
- 新增 session_manager.cleanup_batch_size，历史消息超过上限后按批量清理已总结旧消息
- 补充 WebUI 生命周期、历史消息清理和配置默认值测试

## 验证
- uv run pytest tests/test_event_handler.py tests/test_config_manager.py tests/test_webui_server.py tests/integration/test_plugin_lifecycle_integration.py