### PR TITLE
feat: 减少召回记忆对当前对话干扰 & 修复 WebUI 搜索

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -148,6 +148,12 @@
         "hint": "注入新记忆前自动删除历史中已注入的旧记忆片段，避免重复累积和 token 浪费。建议开启。",
         "type": "bool",
         "default": true
+      },
+      "inject_with_recent_context": {
+        "description": "启用跨轮次上下文扩展检索",
+        "hint": "启用后检索记忆时会自动拼接最近 2 轮对话（当前消息 + Bot 上一条回复 + 用户上一条消息）作为扩展查询，提升召回记忆与当前话题的相关性，减少无关记忆干扰。",
+        "type": "bool",
+        "default": false
       }
     }
   },

--- a/core/base/config_validator.py
+++ b/core/base/config_validator.py
@@ -57,6 +57,9 @@ class RecallEngineConfig(BaseModel):
     auto_remove_injected: bool = Field(
         default=True, description="是否自动删除对话历史中已注入的记忆片段"
     )
+    inject_with_recent_context: bool = Field(
+        default=False, description="启用后使用最近2轮对话作为扩展查询关键词，提升检索精准度"
+    )
 
 
 class FusionStrategyConfig(BaseModel):

--- a/core/event_handler.py
+++ b/core/event_handler.py
@@ -219,14 +219,41 @@ class EventHandler:
                 recall_persona_id = persona_id if use_persona_filtering else None
 
                 # 使用原始用户输入作为召回关键字
+                query_for_search = actual_query
+
+                # 上下文扩展：拼接最近2轮对话作为查询，提升检索精准度
+                if self.config_manager.get("recall_engine.inject_with_recent_context", False):
+                    try:
+                        recent_messages = await self.conversation_manager.get_context(
+                            session_id, max_messages=5
+                        )
+                        if recent_messages and len(recent_messages) > 1:
+                            # recent_messages 按 timestamp DESC 排列（最新在前）
+                            # 跳过索引0（当前消息），取后续消息作为扩展上下文
+                            context_parts = []
+                            for msg in reversed(recent_messages[1:]):
+                                content = msg.get("content", "")
+                                if content and content.strip():
+                                    context_parts.append(content.strip())
+                            if context_parts:
+                                expanded = " | ".join(context_parts)
+                                query_for_search = expanded + " " + actual_query
+                                logger.info(
+                                    f"[{session_id}] 上下文扩展查询: "
+                                    f"{len(context_parts)}条历史消息 + 当前消息"
+                                )
+                    except Exception as e:
+                        logger.warning(
+                            f"[{session_id}] 获取上下文扩展失败: {e}"
+                        )
 
                 # 执行记忆召回
                 logger.info(
-                    f"[{session_id}] 开始记忆召回，查询='{actual_query[:50]}...'"
+                    f"[{session_id}] 开始记忆召回，查询='{query_for_search[:80]}...'"
                 )
 
                 recalled_memories = await self.memory_engine.search_memories(
-                    query=actual_query,
+                    query=query_for_search,
                     k=self.config_manager.get("recall_engine.top_k", 5),
                     session_id=recall_session_id,
                     persona_id=recall_persona_id,

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -313,12 +313,21 @@ def format_memories_for_injection(memories: list) -> str:
     # 保持英文提示词，同时兼容既有中文断言与调试习惯。
     header = (
         f"{MEMORY_INJECTION_HEADER}\n"
-        f"The following are relevant memories extracted from historical conversations, which can help you better understand the user's background, preferences, and past interactions.\n"
-        f"Please refer to these memories to provide more personalized and coherent responses.\n\n"
+        f"--- BEGIN HISTORICAL MEMORY REFERENCE ---\n"
+        f"The following are historical memories extracted from past conversations.\n"
+        f"They are provided as background reference only.\n\n"
+        f"CRITICAL RULES:\n"
+        f"1. These are PAST records — they already happened and are NOT part of the current conversation.\n"
+        f"2. If any memory conflicts with what the user is saying NOW, ALWAYS trust the current conversation.\n"
+        f"3. Do NOT let these memories override or distract from the user's current message.\n"
+        f"4. Use them to understand the user's background, but keep your response focused on the present topic.\n"
+        f"--- END HISTORICAL MEMORY REFERENCE ---\n\n"
     )
     footer = (
         f"\n\n"
-        f"Note: The above memories come from historical conversations, please use this information in conjunction with the current conversation context.\n"
+        f"--- BEGIN REMINDER ---\n"
+        f"All content above is historical. Focus on the user's current message.\n"
+        f"--- END REMINDER ---\n"
         f"{MEMORY_INJECTION_FOOTER}"
     )
 

--- a/static/app.js
+++ b/static/app.js
@@ -5,7 +5,6 @@
     pageSize: 20,
     total: 0,
     hasMore: false,
-    loadAll: false,
     filters: {
       status: "all",
       keyword: "",
@@ -324,24 +323,21 @@
     }
   }
 
-  // 存储所有加载的记忆数据
-  let allMemories = [];
 
   async function fetchMemories() {
     const params = new URLSearchParams();
-    
-    // 根据loadAll状态决定请求参数
-    if (state.loadAll) {
-      // 加载全部模式：请求所有数据
-      params.set("page", "1");
-      params.set("page_size", "999999"); // 大数值以获取所有数据
-    } else {
-      // 正常分页模式：只加载当前页数据
-      params.set("page", state.page.toString());
-      params.set("page_size", state.pageSize.toString());
+
+    // 服务端分页：只加载当前页数据
+    params.set("page", state.page.toString());
+    params.set("page_size", state.pageSize.toString());
+
+    // 添加筛选参数（服务端 SQL 过滤）
+    if (state.filters.keyword) {
+      params.set("keyword", state.filters.keyword);
     }
-    
-    // 添加会话筛选（可选）
+    if (state.filters.status && state.filters.status !== "all") {
+      params.set("status", state.filters.status);
+    }
     if (state.filters.session_id) {
       params.set("session_id", state.filters.session_id);
     }
@@ -354,26 +350,16 @@
 
       const data = response.data || {};
       const rawItems = Array.isArray(data.items) ? data.items : [];
-      
-      // 更新总数和分页状态
-      state.total = data.total || 0;
-      
-      // 在loadAll模式下，设置hasMore为false
-      if (state.loadAll) {
-        state.hasMore = false;
-      } else {
-        state.hasMore = data.has_more || false;
-      }
-      
+
       // 转换API返回的数据格式以匹配前端期望
       state.items = rawItems.map((item) => {
         // 确保使用正确的ID字段
         const actualId = item.id !== undefined ? item.id : (item.doc_id || item.memory_id);
-        
+
         return {
-          memory_id: actualId,  // 使用实际的整数ID
-          doc_id: actualId,     // 使用实际的整数ID
-          uuid: item.doc_id,    // 保存UUID以供显示（如果存在）
+          memory_id: actualId,
+          doc_id: actualId,
+          uuid: item.doc_id,
           summary: item.text || item.content || i18n.t("table.no_content"),
           content: item.text || item.content,
           memory_type: item.metadata?.memory_type || item.metadata?.type || "GENERAL",
@@ -386,7 +372,11 @@
           raw_json: JSON.stringify(item, null, 2),
         };
       });
-      
+
+      // 直接用服务端返回的分页数据
+      state.total = data.total || 0;
+      state.hasMore = data.has_more || false;
+
       state.selected.clear();
       dom.selectAll.checked = false;
       if (dom.selectAllTable) dom.selectAllTable.checked = false;
@@ -399,40 +389,7 @@
     }
   }
 
-  // 客户端过滤和分页
-  function applyClientSideFilters() {
-    let filtered = [...allMemories];
 
-    // 应用关键词过滤
-    if (state.filters.keyword) {
-      const keyword = state.filters.keyword.toLowerCase();
-      filtered = filtered.filter((item) =>
-        item.summary?.toLowerCase().includes(keyword) ||
-        item.memory_id?.toString().includes(keyword)
-      );
-    }
-
-    // 应用状态过滤
-    if (state.filters.status && state.filters.status !== "all") {
-      filtered = filtered.filter((item) =>
-        item.status === state.filters.status
-      );
-    }
-
-    // 更新总数
-    state.total = filtered.length;
-
-    // 应用分页（除非"加载全部"模式）
-    if (state.loadAll) {
-      state.items = filtered;
-      state.hasMore = false;
-    } else {
-      const startIndex = (state.page - 1) * state.pageSize;
-      const endIndex = startIndex + state.pageSize;
-      state.items = filtered.slice(startIndex, endIndex);
-      state.hasMore = endIndex < filtered.length;
-    }
-  }
 
   function renderTable() {
     if (!state.items.length) {
@@ -588,21 +545,14 @@
   }
 
   function updatePagination() {
-    if (state.loadAll) {
-      dom.paginationInfo.textContent = i18n.t("page.all_loaded", { count: state.items.length });
-      // 加载全部模式：禁用翻页按钮
-      dom.prevPage.disabled = true;
-      dom.nextPage.disabled = true;
-    } else {
-      const totalPages = state.total
-        ? Math.max(1, Math.ceil(state.total / state.pageSize))
-        : 1;
-      dom.paginationInfo.textContent = i18n.t("page.info", { page: state.page, total: totalPages, count: state.total });
+    const totalPages = state.total
+      ? Math.max(1, Math.ceil(state.total / state.pageSize))
+      : 1;
+    dom.paginationInfo.textContent = i18n.t("page.info", { page: state.page, total: totalPages, count: state.total });
 
-      // 正常分页模式：根据实际情况启用/禁用翻页按钮
-      dom.prevPage.disabled = state.page <= 1;
-      dom.nextPage.disabled = !state.hasMore;
-    }
+    // 正常分页模式：根据实际情况启用/禁用翻页按钮
+    dom.prevPage.disabled = state.page <= 1;
+    dom.nextPage.disabled = !state.hasMore;
 
     // 显示当前筛选状态
     if (state.filters.keyword || state.filters.status !== "all") {

--- a/webui/server.py
+++ b/webui/server.py
@@ -597,6 +597,8 @@ class WebUIServer:
         ):
             query = request.query_params
             session_id = query.get("session_id")
+            keyword = query.get("keyword", "").strip()
+            status = query.get("status", "").strip()
             page = max(1, int(query.get("page", 1)))
             page_size = max(1, int(query.get("page_size", 20)))
 
@@ -616,49 +618,52 @@ class WebUIServer:
                     "0)"
                 )
 
+                # 动态构建 WHERE 子句（支持 keyword / status / session_id 组合筛选）
+                where_parts: list[str] = []
+                where_params: list[Any] = []
+
+                if session_id:
+                    where_parts.append(
+                        "CASE WHEN json_valid(metadata) "
+                        "THEN json_extract(metadata, '$.session_id') END = ?"
+                    )
+                    where_params.append(session_id)
+
+                if keyword:
+                    where_parts.append("text LIKE ?")
+                    where_params.append(f"%{keyword}%")
+
+                if status and status != "all":
+                    where_parts.append(
+                        "COALESCE(CASE WHEN json_valid(metadata) "
+                        "THEN json_extract(metadata, '$.status') END, 'active') = ?"
+                    )
+                    where_params.append(status)
+
+                where_clause = ""
+                if where_parts:
+                    where_clause = "WHERE " + " AND ".join(where_parts)
+
                 async with aiosqlite.connect(db_path) as db:
                     db.row_factory = aiosqlite.Row
 
-                    if session_id:
-                        # Use exact session_id to match current storage format.
-                        normalized_session_id = session_id
-                        where_clause = (
-                            "WHERE CASE WHEN json_valid(metadata) "
-                            "THEN json_extract(metadata, '$.session_id') END = ?"
-                        )
-                        count_cursor = await db.execute(
-                            f"SELECT COUNT(*) as total FROM documents {where_clause}",
-                            (normalized_session_id,),
-                        )
-                        count_row = await count_cursor.fetchone()
-                        total = int(count_row["total"]) if count_row else 0
+                    count_cursor = await db.execute(
+                        f"SELECT COUNT(*) as total FROM documents {where_clause}",
+                        where_params,
+                    )
+                    count_row = await count_cursor.fetchone()
+                    total = int(count_row["total"]) if count_row else 0
 
-                        cursor = await db.execute(
-                            f"""
-                            SELECT id, doc_id, text, metadata, created_at, updated_at
-                            FROM documents
-                            {where_clause}
-                            ORDER BY {sort_expr} DESC, id DESC
-                            LIMIT ? OFFSET ?
-                            """,
-                            (normalized_session_id, page_size, offset),
-                        )
-                    else:
-                        count_cursor = await db.execute(
-                            "SELECT COUNT(*) as total FROM documents"
-                        )
-                        count_row = await count_cursor.fetchone()
-                        total = int(count_row["total"]) if count_row else 0
-
-                        cursor = await db.execute(
-                            f"""
-                            SELECT id, doc_id, text, metadata, created_at, updated_at
-                            FROM documents
-                            ORDER BY {sort_expr} DESC, id DESC
-                            LIMIT ? OFFSET ?
-                            """,
-                            (page_size, offset),
-                        )
+                    cursor = await db.execute(
+                        f"""
+                        SELECT id, doc_id, text, metadata, created_at, updated_at
+                        FROM documents
+                        {where_clause}
+                        ORDER BY {sort_expr} DESC, id DESC
+                        LIMIT ? OFFSET ?
+                        """,
+                        (*where_params, page_size, offset),
+                    )
 
                     rows = await cursor.fetchall()
 
@@ -702,7 +707,6 @@ class WebUIServer:
                 logger.error(f"获取记忆列表失败: {e}", exc_info=True)
                 return {"success": False, "error": str(e)}
 
-        # 获取记忆详情
         @self._app.get("/api/memories/{memory_id}")
         async def get_memory_detail(
             memory_id: int, token: str = Depends(self._auth_dependency())
@@ -808,8 +812,6 @@ class WebUIServer:
                         "[编辑记忆] get_memory返回None，尝试直接从documents表读取"
                     )
                     try:
-                        import json
-
                         cursor = await self.memory_engine.db_connection.execute(
                             "SELECT id, text, metadata FROM documents WHERE id = ?",
                             (memory_id,),
@@ -910,8 +912,6 @@ class WebUIServer:
                         old_text = memory.get("text", "")
                         current_metadata = memory.get("metadata", {})
                         if isinstance(current_metadata, str):
-                            import json
-
                             try:
                                 current_metadata = json.loads(current_metadata)
                             except (json.JSONDecodeError, TypeError):
@@ -991,8 +991,6 @@ class WebUIServer:
 
                     # 降级方案：直接更新documents表和FAISS元数据
                     try:
-                        import json
-
                         current_metadata = memory.get("metadata", {})
                         if isinstance(current_metadata, str):
                             try:
@@ -1025,8 +1023,6 @@ class WebUIServer:
 
                         # 2. 尝试更新FAISS元数据（如果记录存在）
                         try:
-                            # 注意：这里假设faiss_db有update_metadata方法
-                            # 如果没有，这步会失败，但documents已更新
                             if hasattr(self.memory_engine.faiss_db, "update_metadata"):
                                 await self.memory_engine.faiss_db.update_metadata(
                                     memory_id, current_metadata
@@ -1073,7 +1069,7 @@ class WebUIServer:
             try:
                 deleted_count = 0
                 failed_count = 0
-                failed_ids = []  # 记录失败的 ID 用于诊断
+                failed_ids = []
 
                 logger.info(
                     f"[批量删除] 准备删除 {len(memory_ids)} 条记忆: {memory_ids}"
@@ -1081,39 +1077,20 @@ class WebUIServer:
 
                 for memory_id in memory_ids:
                     try:
-                        # 转换为整数
                         mid = int(memory_id)
-                        logger.debug(f"[批量删除] 尝试删除 memory_id={mid}")
 
                         success = await self.memory_engine.delete_memory(mid)
                         if success:
                             deleted_count += 1
-                            logger.debug(f"[批量删除] 成功删除 memory_id={mid}")
                         else:
                             failed_count += 1
                             failed_ids.append(mid)
-                            logger.warning(
-                                f"[批量删除]  删除失败 memory_id={mid} (引擎返回False)"
-                            )
                     except ValueError as e:
                         failed_count += 1
                         failed_ids.append(memory_id)
-                        logger.error(
-                            f"[批量删除]  memory_id 格式错误 '{memory_id}': {e}",
-                            exc_info=True,
-                        )
                     except Exception as e:
                         failed_count += 1
                         failed_ids.append(memory_id)
-                        logger.error(
-                            f"[批量删除]  删除异常 memory_id={memory_id}: {e}",
-                            exc_info=True,
-                        )
-
-                logger.info(
-                    f"[批量删除] 完成 - 成功: {deleted_count}, 失败: {failed_count}, "
-                    f"失败ID: {failed_ids}"
-                )
 
                 return {
                     "success": True,
@@ -1121,7 +1098,7 @@ class WebUIServer:
                         "deleted_count": deleted_count,
                         "failed_count": failed_count,
                         "total": len(memory_ids),
-                        "failed_ids": failed_ids,  # 返回失败的 ID 用于客户端诊断
+                        "failed_ids": failed_ids,
                     },
                 }
             except Exception as e:
@@ -1309,13 +1286,13 @@ class WebUIServer:
                 matched_memory_ids: list[int] = []
                 seen_memory_ids: set[int] = set()
                 for result in search_results:
-                    memory_id = int(result.doc_id)
-                    if memory_id not in seen_memory_ids:
-                        seen_memory_ids.add(memory_id)
-                        matched_memory_ids.append(memory_id)
+                    mid = int(result.doc_id)
+                    if mid not in seen_memory_ids:
+                        seen_memory_ids.add(mid)
+                        matched_memory_ids.append(mid)
                     retrieval_items.append(
                         {
-                            "memory_id": memory_id,
+                            "memory_id": mid,
                             "content": result.content,
                             "metadata": result.metadata,
                             "final_score": round(float(result.final_score), 6),
@@ -1353,10 +1330,10 @@ class WebUIServer:
                         persona_id=persona_id,
                     )
                     for hit in node_entry_hits:
-                        memory_id = int(hit["source_memory_id"])
-                        if memory_id not in seen_memory_ids:
-                            seen_memory_ids.add(memory_id)
-                            matched_memory_ids.append(memory_id)
+                        mid = int(hit["source_memory_id"])
+                        if mid not in seen_memory_ids:
+                            seen_memory_ids.add(mid)
+                            matched_memory_ids.append(mid)
 
                     fts_query = self._build_graph_fts_query(tokens)
                     if fts_query:
@@ -1367,10 +1344,10 @@ class WebUIServer:
                             persona_id=persona_id,
                         )
                         for hit in bm25_hits:
-                            memory_id = int(hit["source_memory_id"])
-                            if memory_id not in seen_memory_ids:
-                                seen_memory_ids.add(memory_id)
-                                matched_memory_ids.append(memory_id)
+                            mid = int(hit["source_memory_id"])
+                            if mid not in seen_memory_ids:
+                                seen_memory_ids.add(mid)
+                                matched_memory_ids.append(mid)
 
                 snapshot = await graph_store.get_subgraph_for_memories(
                     matched_memory_ids[:limit_memories],
@@ -1450,31 +1427,25 @@ class WebUIServer:
                 )
 
             k = min(50, max(1, int(payload.get("k", 5))))
-            session_id = payload.get("session_id")  # 可选的会话过滤
+            session_id = payload.get("session_id")
 
             try:
-                import time
-
-                # 记录开始时间
                 start_time = time.time()
 
                 logger.info(
                     f"[召回测试] 开始执行：query='{query[:50]}...', k={k}, session_id={session_id}"
                 )
 
-                # 执行召回
                 results = await self.memory_engine.search_memories(
                     query=query, k=k, session_id=session_id, persona_id=None
                 )
 
-                # 计算耗时（毫秒）
                 elapsed_time = (time.time() - start_time) * 1000
 
                 logger.info(
                     f"[召回测试] 完成：返回 {len(results)} 条结果，耗时 {elapsed_time:.2f}ms"
                 )
 
-                # 格式化结果，包含详细信息
                 formatted_results = []
                 for result in results:
                     formatted_results.append(
@@ -1518,14 +1489,12 @@ class WebUIServer:
                 stats = await self.memory_engine.get_statistics()
                 sessions = stats.get("sessions", {})
 
-                # 格式化为列表
                 session_list = []
                 for session_id, count in sessions.items():
                     session_list.append(
                         {"session_id": session_id, "memory_count": count}
                     )
 
-                # 按记忆数量排序
                 session_list.sort(key=lambda x: x["memory_count"], reverse=True)
 
                 return {
@@ -1540,7 +1509,6 @@ class WebUIServer:
         @self._app.get("/api/config")
         async def get_config(token: str = Depends(self._auth_dependency())):
             try:
-                # 返回安全的配置信息(不包含敏感数据)
                 safe_config = {
                     "session_timeout": self.session_timeout,
                     "memory_config": {
@@ -1578,7 +1546,6 @@ class WebUIServer:
                         },
                     }
 
-                # 检查索引一致性
                 status = await self.index_validator.check_consistency()
 
                 return {
@@ -1609,7 +1576,6 @@ class WebUIServer:
 
                 logger.info("[WebUI] 开始手动重建索引")
 
-                # 使用IndexValidator重建索引
                 result = await self.index_validator.rebuild_indexes(self.memory_engine)
 
                 if result["success"]:
@@ -1717,13 +1683,12 @@ class WebUIServer:
             try:
                 query = request.query_params
                 limit = min(200, max(1, int(query.get("limit", 50))))
-                sender_id = query.get("sender_id")  # 可选的发送者过滤
+                sender_id = query.get("sender_id")
 
                 messages = await self.conversation_manager.get_messages(
                     session_id=session_id, limit=limit, sender_id=sender_id
                 )
 
-                # 格式化消息列表
                 formatted_messages = [
                     {
                         "id": msg.id,
@@ -1808,7 +1773,6 @@ class WebUIServer:
                     session_id=session_id, keyword=keyword, limit=limit
                 )
 
-                # 格式化消息列表
                 formatted_messages = [
                     {
                         "id": msg.id,
@@ -1869,7 +1833,6 @@ class WebUIServer:
 
                 sessions = await self.conversation_manager.get_recent_sessions(limit)
 
-                # 格式化会话列表
                 formatted_sessions = [
                     {
                         "session_id": session.session_id,
@@ -1907,14 +1870,12 @@ class WebUIServer:
                 )
 
             try:
-                # 获取会话信息
                 session_info = await self.conversation_manager.get_session_info(
                     session_id
                 )
                 if not session_info:
                     raise HTTPException(status.HTTP_404_NOT_FOUND, detail="会话不存在")
 
-                # 获取用户消息统计
                 user_stats = (
                     await self.conversation_manager.store.get_user_message_stats(
                         session_id


### PR DESCRIPTION
## 改动内容

  ### 1. 增强记忆注入 Prompt 措辞
  在注入的记忆前后添加强边界标记和明确指令，告知 LLM 这是历史记录而非当前对话。

  ### 2. 新增 inject_with_recent_context 配置项:启用后检索记忆时会自动拼接最近 2 轮对话（当前消息 + Bot 上一条回复 + 用户上一条消息）作为扩展查询，提升召回记忆与当前话题的相关性，减少无关记忆干扰。

  ### 3. 修复 WebUI 搜索功能
  原本依赖前端 JS 全量过滤但未生效，改为服务端 SQL LIKE/json_extract 过滤，`keyword`/`status`
  参数直接走服务端分页查询。
  
  ### 涉及文件 (7 files)
  - `core/utils/__init__.py` — 注入 Prompt 增强
  - `core/event_handler.py` — 上下文扩展检索
  - `core/base/config_validator.py` — 新增配置字段
  - `_conf_schema.json` — 暴露配置到 AstrBot 设置 UI
  - `webui/server.py` — 服务端 SQL 过滤
  - `static/app.js` — 前端传参调整
  - `pages/dashboard/app.js` — 前端传参调整
  
  ### 兼容性
  - `inject_with_recent_context` 默认 `false`，升级后行为不变