### PR TITLE
feat: 减少召回记忆对当前对话干扰

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -148,6 +148,12 @@
         "hint": "注入新记忆前自动删除历史中已注入的旧记忆片段，避免重复累积和 token 浪费。建议开启。",
         "type": "bool",
         "default": true
+      },
+      "inject_with_recent_context": {
+        "description": "启用跨轮次上下文扩展检索",
+        "hint": "启用后检索记忆时会自动拼接最近 2 轮对话（当前消息 + Bot 上一条回复 + 用户上一条消息）作为扩展查询，提升召回记忆与当前话题的相关性，减少无关记忆干扰。",
+        "type": "bool",
+        "default": false
       }
     }
   },

--- a/core/base/config_validator.py
+++ b/core/base/config_validator.py
@@ -57,6 +57,9 @@ class RecallEngineConfig(BaseModel):
     auto_remove_injected: bool = Field(
         default=True, description="是否自动删除对话历史中已注入的记忆片段"
     )
+    inject_with_recent_context: bool = Field(
+        default=False, description="启用后使用最近2轮对话作为扩展查询关键词，提升检索精准度"
+    )
 
 
 class FusionStrategyConfig(BaseModel):

--- a/core/event_handler.py
+++ b/core/event_handler.py
@@ -219,14 +219,41 @@ class EventHandler:
                 recall_persona_id = persona_id if use_persona_filtering else None
 
                 # 使用原始用户输入作为召回关键字
+                query_for_search = actual_query
+
+                # 上下文扩展：拼接最近2轮对话作为查询，提升检索精准度
+                if self.config_manager.get("recall_engine.inject_with_recent_context", False):
+                    try:
+                        recent_messages = await self.conversation_manager.get_context(
+                            session_id, max_messages=5
+                        )
+                        if recent_messages and len(recent_messages) > 1:
+                            # recent_messages 按 timestamp DESC 排列（最新在前）
+                            # 跳过索引0（当前消息），取后续消息作为扩展上下文
+                            context_parts = []
+                            for msg in reversed(recent_messages[1:]):
+                                content = msg.get("content", "")
+                                if content and content.strip():
+                                    context_parts.append(content.strip())
+                            if context_parts:
+                                expanded = " | ".join(context_parts)
+                                query_for_search = expanded + " " + actual_query
+                                logger.info(
+                                    f"[{session_id}] 上下文扩展查询: "
+                                    f"{len(context_parts)}条历史消息 + 当前消息"
+                                )
+                    except Exception as e:
+                        logger.warning(
+                            f"[{session_id}] 获取上下文扩展失败: {e}"
+                        )
 
                 # 执行记忆召回
                 logger.info(
-                    f"[{session_id}] 开始记忆召回，查询='{actual_query[:50]}...'"
+                    f"[{session_id}] 开始记忆召回，查询='{query_for_search[:80]}...'"
                 )
 
                 recalled_memories = await self.memory_engine.search_memories(
-                    query=actual_query,
+                    query=query_for_search,
                     k=self.config_manager.get("recall_engine.top_k", 5),
                     session_id=recall_session_id,
                     persona_id=recall_persona_id,

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -313,12 +313,21 @@ def format_memories_for_injection(memories: list) -> str:
     # 保持英文提示词，同时兼容既有中文断言与调试习惯。
     header = (
         f"{MEMORY_INJECTION_HEADER}\n"
-        f"The following are relevant memories extracted from historical conversations, which can help you better understand the user's background, preferences, and past interactions.\n"
-        f"Please refer to these memories to provide more personalized and coherent responses.\n\n"
+        f"--- BEGIN HISTORICAL MEMORY REFERENCE ---\n"
+        f"The following are historical memories extracted from past conversations.\n"
+        f"They are provided as background reference only.\n\n"
+        f"CRITICAL RULES:\n"
+        f"1. These are PAST records — they already happened and are NOT part of the current conversation.\n"
+        f"2. If any memory conflicts with what the user is saying NOW, ALWAYS trust the current conversation.\n"
+        f"3. Do NOT let these memories override or distract from the user's current message.\n"
+        f"4. Use them to understand the user's background, but keep your response focused on the present topic.\n"
+        f"--- END HISTORICAL MEMORY REFERENCE ---\n\n"
     )
     footer = (
         f"\n\n"
-        f"Note: The above memories come from historical conversations, please use this information in conjunction with the current conversation context.\n"
+        f"--- BEGIN REMINDER ---\n"
+        f"All content above is historical. Focus on the user's current message.\n"
+        f"--- END REMINDER ---\n"
         f"{MEMORY_INJECTION_FOOTER}"
     )
 


### PR DESCRIPTION
## 改动内容

增强记忆注入 Prompt，并新增 inject_with_recent_context 配置项。

### 具体改动
1. **增强记忆注入 Prompt 措辞**
   - 在注入的记忆前后添加强边界标记和明确指令，告知 LLM 这是历史记录而非当前对话
   - 涉及文件：`core/utils/__init__.py`

2. **新增 inject_with_recent_context 配置项**
   - 启用后检索记忆时会自动拼接最近 2 轮对话作为扩展查询，提升召回记忆与当前话题的相关性
   - 涉及文件：`core/base/config_validator.py`, `_conf_schema.json`, `core/event_handler.py`

### 兼容性
- `inject_with_recent_context` 默认 `false`，升级后行为不变