### PR TITLE
feat(webui): 记忆管理页面支持按会话 ID 筛选记忆

### DIFF
--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -10,6 +10,7 @@
     filters: {
       status: "all",
       keyword: "",
+      session_id: "",
     },
     items: [],
     selected: new Set(),
@@ -93,6 +94,7 @@
       sessions: document.getElementById("stat-sessions"),
     },
     keywordInput: document.getElementById("keyword-input"),
+    sessionIdInput: document.getElementById("session-id-input"),
     statusFilter: document.getElementById("status-filter"),
     applyFilter: document.getElementById("apply-filter"),
     selectAll: document.getElementById("select-all"),
@@ -156,6 +158,30 @@
           clearTimeout(state.searchTimeout);
         }
         applyFilters();
+      }
+    });
+
+    // Session ID 输入 - 防抖搜索
+    dom.sessionIdInput.addEventListener("input", (event) => {
+      if (state.searchTimeout) {
+        clearTimeout(state.searchTimeout);
+      }
+      state.searchTimeout = setTimeout(() => {
+        state.filters.session_id = event.target.value.trim() || null;
+        state.page = 1;
+        fetchMemories();
+      }, 500);
+    });
+
+    dom.sessionIdInput.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        if (state.searchTimeout) {
+          clearTimeout(state.searchTimeout);
+        }
+        state.filters.session_id = dom.sessionIdInput.value.trim() || null;
+        state.page = 1;
+        fetchMemories();
       }
     });
 
@@ -387,7 +413,7 @@
     });
 
     // 显示搜索结果计数
-    if (state.filters.keyword || state.filters.status !== "all") {
+    if (state.filters.keyword || state.filters.status !== "all" || state.filters.session_id) {
       showToast(`搜索结果：找到 ${state.total} 条记忆，当前显示第 ${state.items.length} 条`);
     }
   }
@@ -451,6 +477,7 @@
   function applyFilters() {
     state.filters.status = dom.statusFilter.value;
     state.filters.keyword = dom.keywordInput.value.trim();
+    state.filters.session_id = dom.sessionIdInput.value.trim() || null;
     state.page = 1;
     
     // 服务端分页：重新请求数据
@@ -499,13 +526,16 @@
     }
 
     // 显示当前筛选状态
-    if (state.filters.keyword || state.filters.status !== "all") {
+    if (state.filters.keyword || state.filters.status !== "all" || state.filters.session_id) {
       let filterInfo = "筛选中:";
       if (state.filters.keyword) {
         filterInfo += ` 关键词="${state.filters.keyword}"`;
       }
       if (state.filters.status !== "all") {
         filterInfo += ` 状态="${state.filters.status}"`;
+      }
+      if (state.filters.session_id) {
+        filterInfo += ` 会话="${state.filters.session_id}"`;
       }
       dom.paginationInfo.textContent += ` | ${filterInfo}`;
     }

--- a/pages/dashboard/index.html
+++ b/pages/dashboard/index.html
@@ -112,6 +112,12 @@
                     placeholder="关键字（支持 memory_id / 内容搜索）"
                     class="form-input"
                   />
+                  <input
+                    type="text"
+                    id="session-id-input"
+                    placeholder="会话 ID（可选）"
+                    class="form-input"
+                  />
                   <select id="status-filter" class="form-select">
                     <option value="all">全部状态</option>
                     <option value="active">活跃</option>

--- a/static/app.js
+++ b/static/app.js
@@ -9,6 +9,7 @@
     filters: {
       status: "all",
       keyword: "",
+      session_id: "",
     },
     items: [],
     selected: new Set(),
@@ -51,6 +52,7 @@
       sessions: document.getElementById("stat-sessions"),
     },
     keywordInput: document.getElementById("keyword-input"),
+    sessionIdInput: document.getElementById("session-id-input"),
     statusFilter: document.getElementById("status-filter"),
     applyFilter: document.getElementById("apply-filter"),
     selectAll: document.getElementById("select-all"),
@@ -124,6 +126,30 @@
           clearTimeout(state.searchTimeout);
         }
         applyFilters();
+      }
+    });
+
+    // Session ID 输入 - 防抖搜索
+    dom.sessionIdInput.addEventListener("input", (event) => {
+      if (state.searchTimeout) {
+        clearTimeout(state.searchTimeout);
+      }
+      state.searchTimeout = setTimeout(() => {
+        state.filters.session_id = event.target.value.trim() || null;
+        state.page = 1;
+        fetchMemories();
+      }, 500);
+    });
+
+    dom.sessionIdInput.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        if (state.searchTimeout) {
+          clearTimeout(state.searchTimeout);
+        }
+        state.filters.session_id = dom.sessionIdInput.value.trim() || null;
+        state.page = 1;
+        fetchMemories();
       }
     });
 
@@ -491,7 +517,7 @@
     });
 
     // 显示搜索结果计数
-    if (state.filters.keyword || state.filters.status !== "all") {
+    if (state.filters.keyword || state.filters.status !== "all" || state.filters.session_id) {
       showToast(i18n.t("toast.search_results", { total: state.total, shown: state.items.length }));
     }
   }
@@ -557,6 +583,7 @@
   function applyFilters() {
     state.filters.status = dom.statusFilter.value;
     state.filters.keyword = dom.keywordInput.value.trim();
+    state.filters.session_id = dom.sessionIdInput.value.trim() || null;
     state.page = 1;
     
     // 服务端分页：重新请求数据
@@ -605,13 +632,16 @@
     }
 
     // 显示当前筛选状态
-    if (state.filters.keyword || state.filters.status !== "all") {
+    if (state.filters.keyword || state.filters.status !== "all" || state.filters.session_id) {
       let filterInfo = i18n.t("page.filtering") + ":";
       if (state.filters.keyword) {
         filterInfo += ` ${i18n.t("page.keyword")}="${state.filters.keyword}"`;
       }
       if (state.filters.status !== "all") {
         filterInfo += ` ${i18n.t("page.status")}="${state.filters.status}"`;
+      }
+      if (state.filters.session_id) {
+        filterInfo += ` ${i18n.t("page.session")}="${state.filters.session_id}"`;
       }
       dom.paginationInfo.textContent += ` | ${filterInfo}`;
     }

--- a/static/i18n.js
+++ b/static/i18n.js
@@ -44,6 +44,7 @@ const TRANSLATIONS = {
     "toolbar.select_all": "全选",
     "toolbar.delete_selected": "删除选中",
     "toolbar.deleting": "删除中...",
+    "toolbar.session_placeholder": "输入会话 ID 筛选（可选）",
 
     // Stats
     "stat.total": "总记忆",
@@ -80,6 +81,7 @@ const TRANSLATIONS = {
     "page.filtering": "筛选中",
     "page.keyword": "关键词",
     "page.status": "状态",
+    "page.session": "会话",
 
     // Detail Drawer
     "detail.title": "记忆详情",
@@ -328,6 +330,7 @@ const TRANSLATIONS = {
     "toolbar.select_all": "Select All",
     "toolbar.delete_selected": "Delete Selected",
     "toolbar.deleting": "Deleting...",
+    "toolbar.session_placeholder": "Enter session ID to filter (optional)",
 
     // Stats
     "stat.total": "Total Memories",
@@ -364,6 +367,7 @@ const TRANSLATIONS = {
     "page.filtering": "Filtering",
     "page.keyword": "Keyword",
     "page.status": "Status",
+    "page.session": "Session",
 
     // Detail Drawer
     "detail.title": "Memory Details",

--- a/static/index.html
+++ b/static/index.html
@@ -185,6 +185,13 @@
                   placeholder="关键字（支持 memory_id / 内容搜索）"
                   class="form-input"
                 />
+                <input
+                  type="text"
+                  id="session-id-input"
+                  data-i18n-placeholder="toolbar.session_placeholder"
+                  placeholder="输入会话 ID 筛选（可选）"
+                  class="form-input"
+                />
                 <select id="status-filter" class="form-select">
                   <option value="all" data-i18n="toolbar.status_all">全部状态</option>
                   <option value="active" data-i18n="toolbar.status_active">活跃</option>


### PR DESCRIPTION
## 变更内容

在 WebUI 记忆管理页面新增 **会话 ID 筛选输入框**，用户可按 `session_id` 精确过滤某个会话的全部记忆，配合现有的「全选 + 批量删除」功能实现一键删除指定会话记忆。

## 主要改动

- `pages/dashboard/app.js` / `static/app.js`：
  - `state.filters` 新增 `session_id` 字段
  - `dom` 对象新增 `sessionIdInput` 引用
  - 新增防抖 `input` 事件监听器（500ms）和 `Enter` 快速搜索
  - `applyFilters()` 同步 `session_id` 到筛选状态
  - `updatePagination()` 分页信息追加会话筛选状态显示
  - `renderTable()` Toast 提示条件扩展为包含 `session_id`

- `pages/dashboard/index.html` / `static/index.html`：
  - 在筛选区域 `input-group` 中添加 `session-id-input` 输入框
  - Legacy WebUI 输入框附带 `data-i18n-placeholder` 国际化属性

- `static/i18n.js`：
  - 新增 `toolbar.session_placeholder`（zh/en）
  - 新增 `page.session`（zh/en）

## 兼容性

- **零后端改动**：`core/page_api.py` 的 `list_memories` 和 `batch_delete_memories` 已原生支持 `session_id` 参数
- 同时覆盖旧独立 WebUI（`static/`）与 AstrBot 官方插件页（`pages/dashboard/`）
- 不影响现有 keyword / status 筛选逻辑

## 验证方式

1. 在 WebUI 记忆管理页「会话 ID」输入框填入完整的 `unified_msg_origin`
2. 等待 500ms 防抖或按 Enter → 表格仅显示该会话记忆
3. 勾选「全选」→ 点击「删除选中」→ 确认后批量删除
4. 清空输入框 → 恢复显示全部记忆