### PR TITLE
fix(memory): 修复原子配置未注入导致的总结失败

### DIFF
--- a/core/managers/memory_engine.py
+++ b/core/managers/memory_engine.py
@@ -104,8 +104,10 @@ class MemoryEngine:
         self.config = config or {}
         self.graph_enabled = bool(self.config.get("graph_memory_enabled", False))
         self.atom_enabled = bool(
-            self.config.get("graph_memory_atom_enabled", True)
-            or self.config.get("atom_enabled", False)
+            self.config.get(
+                "atom_enabled",
+                self.config.get("graph_memory_atom_enabled", True),
+            )
         )
 
         # 确保数据库目录存在

--- a/core/plugin_initializer.py
+++ b/core/plugin_initializer.py
@@ -384,6 +384,15 @@ class PluginInitializer:
                 "graph_max_facts": self.config_manager.get(
                     "graph_memory.max_facts_per_memory", 8
                 ),
+                "atom_enabled": self.config_manager.get(
+                    "graph_memory.atom_enabled", True
+                ),
+                "atom_maintenance_interval_hours": self.config_manager.get(
+                    "graph_memory.atom_maintenance_interval_hours", 24.0
+                ),
+                "atom_forget_delay_days": self.config_manager.get(
+                    "graph_memory.atom_forget_delay_days", 7.0
+                ),
                 "index_rebuild_batch_size": self.config_manager.get(
                     "index_rebuild_settings.batch_size", 50
                 ),
@@ -444,7 +453,9 @@ class PluginInitializer:
             # 导致的 "Cannot send a request, as the client has been closed" 错误。
             llm_id = self.config_manager.get("provider_settings.llm_provider_id")
             self.memory_processor = MemoryProcessor(
-                self.context, llm_provider=llm_id if llm_id else None
+                self.context,
+                llm_provider=llm_id if llm_id else None,
+                config=memory_engine_config,
             )
             logger.info("MemoryProcessor 已初始化")
 

--- a/core/processors/memory_processor.py
+++ b/core/processors/memory_processor.py
@@ -25,7 +25,12 @@ class MemoryProcessor:
     支持私聊和群聊两种场景的不同处理策略。
     """
 
-    def __init__(self, context=None, llm_provider: Any = None):
+    def __init__(
+        self,
+        context=None,
+        llm_provider: Any = None,
+        config: dict[str, Any] | None = None,
+    ):
         """
         初始化记忆处理器
 
@@ -34,9 +39,11 @@ class MemoryProcessor:
             llm_provider: LLM Provider 实例或 Provider ID 字符串。
                           传入实例时直接使用（测试用）；传入字符串时动态解析。
                           留空则使用AstrBot默认Provider。
+            config: 记忆处理器配置。
         """
         self.context = context
         self._llm_provider = llm_provider
+        self.config = config or {}
 
         # 加载提示词模板
         self._load_prompts()

--- a/tests/test_memory_atom.py
+++ b/tests/test_memory_atom.py
@@ -747,6 +747,27 @@ def test_classify_atoms_from_metadata_atom_disabled() -> None:
     assert atoms == []
 
 
+def test_classify_atoms_from_metadata_atom_enabled_returns_atoms() -> None:
+    from astrbot_plugin_livingmemory.core.processors.memory_processor import MemoryProcessor
+
+    processor = MemoryProcessor(config={"atom_enabled": True})
+    atoms = processor.classify_atoms_from_metadata(
+        metadata={
+            "key_facts": ["用户喜欢猫"],
+            "topics": ["宠物"],
+            "participants": ["用户"],
+        },
+        parent_importance=0.8,
+        session_id="test-session",
+        persona_id="test-persona",
+    )
+
+    assert len(atoms) == 1
+    assert atoms[0].content == "用户喜欢猫"
+    assert atoms[0].session_id == "test-session"
+    assert atoms[0].persona_id == "test-persona"
+
+
 def test_classify_atoms_from_metadata_no_key_facts() -> None:
     """When key_facts is empty, classify_atoms_from_metadata returns empty list."""
     from astrbot_plugin_livingmemory.core.processors.memory_processor import MemoryProcessor
@@ -843,4 +864,3 @@ async def test_atom_store_get_stats(tmp_path: Path) -> None:
     assert stats["active"] >= 2
     assert "expired" in stats
     assert "forgotten" in stats
-

--- a/tests/test_memory_atom.py
+++ b/tests/test_memory_atom.py
@@ -727,12 +727,20 @@ def test_graph_extractor_atoms_no_entities_fallback() -> None:
 # ---------- Backward compatibility ----------
 
 
+def test_classify_atoms_from_metadata_default_config() -> None:
+    """MemoryProcessor initializes atom config for direct construction."""
+    from astrbot_plugin_livingmemory.core.processors.memory_processor import MemoryProcessor
+
+    processor = MemoryProcessor()
+    atoms = processor.classify_atoms_from_metadata(metadata={"key_facts": []})
+    assert atoms == []
+
+
 def test_classify_atoms_from_metadata_atom_disabled() -> None:
     """When atom_enabled is False, classify_atoms_from_metadata returns empty list."""
     from astrbot_plugin_livingmemory.core.processors.memory_processor import MemoryProcessor
 
-    processor = MemoryProcessor.__new__(MemoryProcessor)
-    processor.config = {"atom_enabled": False}
+    processor = MemoryProcessor(config={"atom_enabled": False})
     atoms = processor.classify_atoms_from_metadata(
         metadata={"key_facts": ["测试1", "测试2"]},
     )
@@ -743,8 +751,7 @@ def test_classify_atoms_from_metadata_no_key_facts() -> None:
     """When key_facts is empty, classify_atoms_from_metadata returns empty list."""
     from astrbot_plugin_livingmemory.core.processors.memory_processor import MemoryProcessor
 
-    processor = MemoryProcessor.__new__(MemoryProcessor)
-    processor.config = {"atom_enabled": True}
+    processor = MemoryProcessor(config={"atom_enabled": True})
     atoms = processor.classify_atoms_from_metadata(
         metadata={"key_facts": [], "topics": ["会议"]},
     )

--- a/tests/test_memory_engine.py
+++ b/tests/test_memory_engine.py
@@ -99,6 +99,16 @@ class _FakeFaissDB:
             self.docs.pop(target, None)
 
 
+def test_memory_engine_atom_enabled_honors_explicit_false(tmp_path: Path):
+    engine = MemoryEngine(
+        db_path=str(tmp_path / "memory.db"),
+        faiss_db=_FakeFaissDB(),
+        config={"atom_enabled": False},
+    )
+
+    assert engine.atom_enabled is False
+
+
 @pytest.mark.asyncio
 async def test_initialize_drops_legacy_documents_fts_triggers(tmp_path: Path):
     db_path = tmp_path / "legacy_trigger.db"

--- a/tests/test_plugin_initializer.py
+++ b/tests/test_plugin_initializer.py
@@ -158,6 +158,7 @@ async def test_complete_initialization_wires_graph_db_and_engine_config(
         def __init__(self, context=None, llm_provider=None, **kwargs):
             self.context = context
             self.llm_provider = llm_provider
+            self.config = kwargs.get("config", {})
 
     class FakeIndexValidator:
         def __init__(self, db_path, db):
@@ -228,6 +229,9 @@ async def test_complete_initialization_wires_graph_db_and_engine_config(
                     "max_topics_per_memory": 4,
                     "max_participants_per_memory": 5,
                     "max_facts_per_memory": 6,
+                    "atom_enabled": False,
+                    "atom_maintenance_interval_hours": 12.0,
+                    "atom_forget_delay_days": 3.0,
                 },
             }
         ),
@@ -253,6 +257,10 @@ async def test_complete_initialization_wires_graph_db_and_engine_config(
     assert init.memory_engine.config["graph_max_topics"] == 4
     assert init.memory_engine.config["graph_max_participants"] == 5
     assert init.memory_engine.config["graph_max_facts"] == 6
+    assert init.memory_engine.config["atom_enabled"] is False
+    assert init.memory_engine.config["atom_maintenance_interval_hours"] == 12.0
+    assert init.memory_engine.config["atom_forget_delay_days"] == 3.0
+    assert init.memory_processor.config is init.memory_engine.config
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题说明

启用记忆总结后，`MemoryProcessor.classify_atoms_from_metadata()` 会读取 `self.config`，但 `MemoryProcessor.__init__()` 没有初始化该属性，初始化器也没有传入配置。因此在总结流程完成 LLM 处理后会抛出：

```text
AttributeError: 'MemoryProcessor' object has no attribute 'config'
```

由于异常位于统一的 LLM 处理重试块内，日志会显示为“LLM处理失败”，并重复重试，实际根因是原子分类器配置未注入。

另外，`graph_memory` 下的原子配置没有被扁平化传递给 `MemoryEngine`；`MemoryEngine` 对 `atom_enabled` 的兼容读取逻辑也会因为默认值为 `True` 而忽略显式关闭配置。

## 修复内容

- 为 `MemoryProcessor` 增加可选 `config` 参数并默认初始化为空字典，兼容现有直接构造调用。
- 在 `PluginInitializer` 中传递以下原子配置：
  - `graph_memory.atom_enabled`
  - `graph_memory.atom_maintenance_interval_hours`
  - `graph_memory.atom_forget_delay_days`
- 将同一份扁平配置注入 `MemoryProcessor` 和 `MemoryEngine`。
- 修复 `MemoryEngine.atom_enabled` 的兼容读取顺序，使显式 `False` 生效，同时保留旧键 `graph_memory_atom_enabled` 的兼容支持。
- 用真实构造路径替换原先通过 `__new__` 手工注入 `config` 的测试，并补充初始化器和引擎级回归测试。
- 补充 `atom_enabled=True` 时生成原子并透传 `session_id`、`persona_id` 的正向路径测试。

## 验证结果

已通过：

```text
132 passed, 1 warning
```

执行范围：

```text
tests/test_memory_atom.py
tests/test_memory_engine.py
tests/test_plugin_initializer.py
tests/test_memory_processor.py
tests/test_features_77_76_74_59.py
```

同时已通过：

```text
python -m compileall -q core tests
git -c core.whitespace=cr-at-eol diff --cached --check
```

## 全量测试说明

全量 `pytest` 在收集阶段仍会被仓库现有测试环境问题阻塞，与本次改动无关：

- `tests/conftest.py` 的 AstrBot 桩缺少 `filter.PlatformAdapterType`。
- 临时测试环境未包含 `faiss` 和 `quart`。
- `tests/integration/test_real_db_end_to_end.py` 的 `_DeterministicEmbeddingProvider` 基类桩不接受构造参数。

关联问题：#154