### PR TITLE
feat(dashboard): 记忆列表增加按 ID/重要性/创建时间排序功能

### DIFF
--- a/core/page_api.py
+++ b/core/page_api.py
@@ -240,30 +240,28 @@ class PluginPageApi:
 
         where_clause = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
-        if sort_field == "importance":
-            sort_expr = (
+        sort_exprs = {
+            "importance": (
                 "COALESCE("
                 "CASE WHEN json_valid(metadata) "
                 "THEN CAST(json_extract(metadata, '$.importance') AS REAL) END,"
                 "5)"
-            )
-        elif sort_field == "id":
-            sort_expr = "CAST(id AS REAL)"
-        elif sort_field == "created_at":
-            sort_expr = (
-                "COALESCE("
-                "CASE WHEN json_valid(metadata) "
-                "THEN CAST(json_extract(metadata, '$.create_time') AS REAL) END,"
-                "0)"
-            )
-        else:
-            sort_expr = (
-                "COALESCE("
-                "CASE WHEN json_valid(metadata) "
-                "THEN CAST(json_extract(metadata, '$.create_time') AS REAL) END,"
-                "0)"
-            )
+            ),
+            "id": "CAST(id AS INTEGER)",
+        }
+
+        if sort_field is None:
             sort_order = "desc"
+
+        sort_expr = sort_exprs.get(
+            sort_field,
+            (
+                "COALESCE("
+                "CASE WHEN json_valid(metadata) "
+                "THEN CAST(json_extract(metadata, '$.create_time') AS REAL) END,"
+                "0)"
+            ),
+        )
 
         order_sql = "ASC" if sort_order == "asc" else "DESC"
 

--- a/core/page_api.py
+++ b/core/page_api.py
@@ -181,6 +181,18 @@ class PluginPageApi:
         except (TypeError, ValueError):
             return self._error("分页参数无效")
 
+        sort_field_raw = query.get("sort")
+        sort_field = str(sort_field_raw).strip().lower() if sort_field_raw else None
+        sort_order = str(query.get("order", "desc")).strip().lower()
+
+        ALLOWED_SORT_FIELDS = {"id", "created_at", "importance"}
+        ALLOWED_SORT_ORDERS = {"asc", "desc"}
+
+        if sort_field not in ALLOWED_SORT_FIELDS:
+            sort_field = None
+        if sort_order not in ALLOWED_SORT_ORDERS:
+            sort_order = "desc"
+
         db_path = getattr(memory_engine, "db_path", None)
         if not db_path:
             return self._error("MemoryEngine db_path unavailable")
@@ -227,12 +239,33 @@ class PluginPageApi:
                 params.extend([keyword_like, keyword_like])
 
         where_clause = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
-        sort_expr = (
-            "COALESCE("
-            "CASE WHEN json_valid(metadata) "
-            "THEN CAST(json_extract(metadata, '$.create_time') AS REAL) END,"
-            "0)"
-        )
+
+        if sort_field == "importance":
+            sort_expr = (
+                "COALESCE("
+                "CASE WHEN json_valid(metadata) "
+                "THEN CAST(json_extract(metadata, '$.importance') AS REAL) END,"
+                "5)"
+            )
+        elif sort_field == "id":
+            sort_expr = "CAST(id AS REAL)"
+        elif sort_field == "created_at":
+            sort_expr = (
+                "COALESCE("
+                "CASE WHEN json_valid(metadata) "
+                "THEN CAST(json_extract(metadata, '$.create_time') AS REAL) END,"
+                "0)"
+            )
+        else:
+            sort_expr = (
+                "COALESCE("
+                "CASE WHEN json_valid(metadata) "
+                "THEN CAST(json_extract(metadata, '$.create_time') AS REAL) END,"
+                "0)"
+            )
+            sort_order = "desc"
+
+        order_sql = "ASC" if sort_order == "asc" else "DESC"
 
         try:
             async with aiosqlite.connect(db_path) as db:
@@ -250,7 +283,7 @@ class PluginPageApi:
                     SELECT id, doc_id, text, metadata, created_at, updated_at
                     FROM documents
                     {where_clause}
-                    ORDER BY {sort_expr} DESC, id DESC
+                    ORDER BY {sort_expr} {order_sql}, id {order_sql}
                     LIMIT ? OFFSET ?
                     """,
                     (*params, page_size, offset),

--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -16,6 +16,8 @@
       keyword: "",
       session: "",
       status: "all",
+      sortField: null,
+      sortOrder: "desc",
     },
     selectedMemory: null,
     isEditing: false,
@@ -740,6 +742,10 @@
     if (state.memory.session) params.set("session_id", state.memory.session);
     if (state.memory.keyword) params.set("keyword", state.memory.keyword);
     if (state.memory.status && state.memory.status !== "all") params.set("status", state.memory.status);
+    if (state.memory.sortField) {
+      params.set("sort", state.memory.sortField);
+      params.set("order", state.memory.sortOrder);
+    }
 
     try {
       var data = unwrapApiData(await apiRequest("memories?" + params.toString())) || {};
@@ -770,6 +776,7 @@
       });
 
       renderMemoriesVirtual({ resetScroll: true });
+      updateSortIndicators();
       updateMemoryPagination();
       updateBatchBar();
       syncSelectAllCheckbox();
@@ -837,6 +844,15 @@
     tbody.innerHTML = '<tr><td colspan="7" class="table-empty">' + window.t("table.noData") + '</td></tr>';
     tbody.style.paddingTop = "0";
     tbody.style.paddingBottom = "0";
+  }
+
+  function updateSortIndicators() {
+    document.querySelectorAll("#memories-table th.sortable").forEach(function(th) {
+      th.classList.remove("asc", "desc");
+      if (state.memory.sortField && th.dataset.sort === state.memory.sortField) {
+        th.classList.add(state.memory.sortOrder);
+      }
+    });
   }
 
   function getMemoryItemByKey(key) {
@@ -1022,6 +1038,26 @@
       state.memory.selected.clear();
       renderMemoriesVirtual();
       updateBatchBar();
+    });
+
+    document.querySelectorAll("#memories-table th.sortable").forEach(function(th) {
+      th.addEventListener("click", function() {
+        var field = this.dataset.sort;
+        if (state.memory.sortField === field) {
+          if (state.memory.sortOrder === "desc") {
+            state.memory.sortOrder = "asc";
+          } else {
+            state.memory.sortField = null;
+            state.memory.sortOrder = "desc";
+          }
+        } else {
+          state.memory.sortField = field;
+          state.memory.sortOrder = "desc";
+        }
+        state.memory.page = 1;
+        fetchMemories();
+        updateSortIndicators();
+      });
     });
   }
 

--- a/pages/dashboard/index.html
+++ b/pages/dashboard/index.html
@@ -136,12 +136,12 @@
                 <thead>
                   <tr>
                     <th class="cell-check"><input type="checkbox" id="mem-select-page" data-i18n-aria="table.selectPage" aria-label="Select page" /></th>
-                    <th class="cell-id" data-i18n="table.id">ID</th>
+                    <th class="cell-id sortable" data-sort="id" data-i18n="table.id">ID</th>
                     <th class="cell-summary" data-i18n="table.summary">Summary</th>
                     <th class="cell-type" data-i18n="table.type">Type</th>
-                    <th class="cell-importance" data-i18n="table.importance">Importance</th>
+                    <th class="cell-importance sortable" data-sort="importance" data-i18n="table.importance">Importance</th>
                     <th class="cell-status" data-i18n="table.status">Status</th>
-                    <th class="cell-created" data-i18n="table.created">Created</th>
+                    <th class="cell-created sortable" data-sort="created_at" data-i18n="table.created">Created</th>
                   </tr>
                 </thead>
                 <tbody id="memories-body">

--- a/pages/dashboard/styles.css
+++ b/pages/dashboard/styles.css
@@ -604,6 +604,29 @@ body {
   white-space: nowrap;
 }
 
+.data-table th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+.data-table th.sortable:hover {
+  color: var(--accent);
+}
+.data-table th.sortable::after {
+  content: "";
+  display: inline-block;
+  margin-left: 4px;
+  font-size: 10px;
+  opacity: 0.3;
+}
+.data-table th.sortable.asc::after {
+  content: "▲";
+  opacity: 1;
+}
+.data-table th.sortable.desc::after {
+  content: "▼";
+  opacity: 1;
+}
+
 .data-table td {
   padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--border-light);
@@ -1167,6 +1190,7 @@ body {
   margin-top: var(--space-1);
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
@@ -1576,6 +1600,7 @@ body {
   line-height: 1.6;
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   margin-bottom: var(--space-3);


### PR DESCRIPTION
## 变更内容

在 WebUI 记忆管理页面新增记忆列表排序功能，支持按**记忆 ID**、**重要性**、**创建时间**三列排序，采用三段式点击交互（降序 → 升序 → 恢复默认）。

## 主要改动

### 后端（`core/page_api.py`）

- `list_memories` API 新增 `sort` / `order` 查询参数解析，支持白名单字段 `id`、`created_at`、`importance`，方向 `asc` / `desc`
- 动态构建 `ORDER BY` 子句：
  - `id` → `CAST(id AS REAL)`
  - `created_at` → `COALESCE(json_extract(metadata, '$.create_time'), 0)`
  - `importance` → `COALESCE(json_extract(metadata, '$.importance'), 5)`
- `else` 分支强制回退 `sort_order = "desc"`，防止仅传 `order=asc` 而不传 `sort` 的畸变请求逆转默认排序方向
- 白名单校验杜绝 SQL 注入，非法输入静默回退至 `created_at DESC`

### 前端（`pages/dashboard/`）

- `app.js`：
  - `state.memory` 扩展 `sortField`（`null` 表示无主动排序，回退默认）和 `sortOrder` 字段
  - `fetchMemories()` 仅在 `sortField` 非空时传递 `sort` / `order` 参数
  - 新增 `updateSortIndicators()` 函数，统一管理表头箭头样式，切换列时自动清除旧列标识
  - `initMemoryPage()` 末尾绑定表头三段式点击事件：
    - 第一下 → 该列降序（▼）
    - 第二下 → 该列升序（▲）
    - 第三下 → 恢复默认 `created_at DESC`（箭头消失）
    - 切换列 → 新列降序，旧列箭头消失
  - 排序后自动跳回第 1 页

- `index.html`：ID / 重要性 / 创建时间三列表头添加 `sortable` class 及 `data-sort` 属性

- `styles.css`：
  - 新增 `.data-table th.sortable` 排序指示器样式（cursor、hover 高亮、箭头 ▲/▼）
  - 补充 `line-clamp` 标准属性（VSCode vendorPrefix 警告修复）

## 交互行为

| 操作 | 效果 |
|---|---|
| 点击某列表头（首次） | 该列降序，显示 ▼ |
| 再次点击同一表头 | 该列升序，显示 ▲ |
| 第三次点击同一表头 | 恢复默认排序（创建时间降序），箭头消失 |
| 从 A 列切换到 B 列 | B 列降序，A 列箭头消失 |
| 排序后翻页 / 过滤 / 批量操作 | 保持当前排序规则 |

## 兼容性

- **零破坏性变更**：未删除或修改现有 API 行为；前端不传 `sort` 参数时后端自动回退 `created_at DESC`，与修改前完全一致
- 现有关键词搜索、会话 ID 过滤、状态过滤、分页、批量操作等功能不受影响
- `importance` 默认值 `5` 与前端 `normalizeImportance` 一致（缺失值 0.5 × 10 = 5）

## 预览

排序功能涉及三列表头：

```
┌──────┬──────────┬──────┬───────────┬────────┬──────────┐
│  ☐   │  ID ▼▲  │ 摘要  │  类型     │ 重要性 ▼▲ │ 状态 │ 创建时间 ▼▲ │
├──────┼──────────┼──────┼───────────┼────────┼──────────┤
│ ...  │   123    │ ...  │  GENERAL  │ 8.5 ██ │ active │ 2026/...  │
└──────┴──────────┴──────┴───────────┴────────┴──────────┘
```

## 验证方式

1. 打开 WebUI 记忆管理页 → 默认按创建时间降序排列，表头无箭头
2. 点击「重要性」表头 → 记忆按重要性降序排列，表头显示 ▼
3. 再次点击「重要性」→ 按重要性升序排列，表头显示 ▲
4. 第三次点击「重要性」→ 恢复默认排序，箭头消失
5. 点击「记忆 ID」→ 按 ID 降序，ID 表头显示 ▼，重要性表头箭头消失
6. 排序后切换关键词搜索 / 会话过滤 / 分页 → 排序规则保持
7. 浏览器控制台无报错，网络请求携带正确的 `sort` / `order` 参数

## 安全

- SQL 注入防护：`sort` 白名单 `{id, created_at, importance}`，`order` 白名单 `{asc, desc}`，非法值静默回退
- 所有进入 SQL 的值为 Python 字符串常量，零用户输入拼接

## 代码审查

除本地功能测试外，三段式排序状态机及后端 SQL 构建逻辑已通过 Kimi K2.6 和 DeepSeek V4 Pro 的逐场景逻辑推演审查，确认状态迁移闭合、SQL 安全措施无损、无引入新 bug。


<img width="189" height="783" alt="d1a6193cbf0b4be075fc110ceedd5ab9" src="https://github.com/user-attachments/assets/7f6968c7-9e15-43b2-9084-d43657502898" />
<img width="224" height="365" alt="4bfbdf742434cd7d331576281556f128" src="https://github.com/user-attachments/assets/e3550825-edea-47ab-a984-8c8c2838f527" />
