### PR TITLE
fix: pass plugin name to StarTools.get_data_dir() to avoid inspect.stack() crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ class LivingMemoryPlugin(Star):
         self.context = context
 
         # 获取插件数据目录
-        data_dir = str(StarTools.get_data_dir())
+        data_dir = str(StarTools.get_data_dir("astrbot_plugin_livingmemory"))
 
         # 版本变更时自动备份数据（延迟到异步初始化阶段执行，避免 __init__ 中同步 I/O 阻塞）
         self._backup_manager = BackupManager(data_dir)


### PR DESCRIPTION
### Problem
When `StarTools.get_data_dir()` is called without arguments, the framework attempts to deduce the calling plugin name using `inspect.stack()`. Under certain environments (such as dynamic reloading, testing shims, or direct scripts where `__main__` is the entrypoint), metadata extraction fails, throwing a fatal `RuntimeError: 无法获取模块 __main__ 的元信息`.

### Solution
Explicitly pass the plugin name `"astrbot_plugin_livingmemory"` to the call of `StarTools.get_data_dir()` in `main.py` to avoid this dynamic inspection crash. This is safe, backwards-compatible, and robust across all execution environments.

### Validation
- Verified and tested successfully under AstrBot official environment.

---

### 💡 Ecosystem & Framework Context
This issue stems from a known vulnerability in the AstrBot core framework's path-resolving API. We have submitted a root-cause fix to the official AstrBot core repository: **[AstrBot Core PR #8588](https://github.com/AstrBotDevs/AstrBot/pull/8588)**.

However, this plugin-level change (passing the plugin name explicitly) remains **highly necessary** to ensure backward compatibility. It prevents the plugin from crashing on older installations of AstrBot that have not upgraded to the latest core version.

This is a safe, non-breaking, and recommended change.