### PR TITLE
fix: 修复群聊全量捕获误唤醒 AstrBot 的问题

### DIFF
--- a/core/passive_group_capture.py
+++ b/core/passive_group_capture.py
@@ -1,0 +1,139 @@
+"""Passive group capture helpers for LivingMemory."""
+
+import weakref
+from typing import Any
+
+from astrbot.api import logger, sp
+from astrbot.api.event import AstrMessageEvent
+from astrbot.api.event.filter import CustomFilter
+from astrbot.api.platform import MessageType
+
+SESSION_PLUGIN_NAMES = ("LivingMemory", "astrbot_plugin_livingmemory")
+_ACTIVE_PLUGIN_REF: weakref.ReferenceType | None = None
+
+
+def set_active_plugin(plugin: Any) -> None:
+    """Track the active plugin instance for passive filter side effects."""
+    global _ACTIVE_PLUGIN_REF
+    _ACTIVE_PLUGIN_REF = weakref.ref(plugin) if plugin is not None else None
+
+
+def get_active_plugin() -> Any:
+    if _ACTIVE_PLUGIN_REF is None:
+        return None
+    return _ACTIVE_PLUGIN_REF()
+
+
+async def is_session_enabled(session_id: str) -> bool:
+    """Mirror AstrBot's session-level shutdown check for passive capture."""
+    try:
+        session_services = await sp.get_async(
+            scope="umo",
+            scope_id=session_id,
+            key="session_service_config",
+            default={},
+        )
+    except Exception as exc:
+        logger.debug(f"[{session_id}] 读取会话总开关失败，默认允许捕获: {exc}")
+        return True
+
+    if not isinstance(session_services, dict):
+        return True
+    session_enabled = session_services.get("session_enabled")
+    return True if session_enabled is None else bool(session_enabled)
+
+
+async def is_plugin_enabled_for_session(session_id: str) -> bool:
+    """Mirror AstrBot session-level plugin disable checks for passive capture."""
+    try:
+        session_plugin_config = await sp.get_async(
+            scope="umo",
+            scope_id=session_id,
+            key="session_plugin_config",
+            default={},
+        )
+    except Exception as exc:
+        logger.debug(f"[{session_id}] 读取会话插件开关失败，默认允许捕获: {exc}")
+        return True
+
+    if not isinstance(session_plugin_config, dict):
+        return True
+    session_config = session_plugin_config.get(session_id, {})
+    if not isinstance(session_config, dict):
+        return True
+    disabled_plugins = session_config.get("disabled_plugins", [])
+    if not isinstance(disabled_plugins, list):
+        return True
+    return not any(name in disabled_plugins for name in SESSION_PLUGIN_NAMES)
+
+
+class PassiveGroupCaptureFilter(CustomFilter):
+    """Schedule group-message capture without waking AstrBot's message pipeline."""
+
+    def __init__(self, raise_error: bool = True, plugin=None, **kwargs) -> None:
+        if not isinstance(raise_error, bool) and plugin is None:
+            plugin = raise_error
+            raise_error = True
+        super().__init__(raise_error=raise_error, **kwargs)
+        self._plugin_ref = weakref.ref(plugin) if plugin is not None else None
+
+    def _get_plugin(self):
+        if self._plugin_ref is not None:
+            return self._plugin_ref()
+        return get_active_plugin()
+
+    @staticmethod
+    def _passes_global_whitelist(event: AstrMessageEvent, cfg) -> bool:
+        platform_settings = (
+            cfg.get("platform_settings", {}) if isinstance(cfg, dict) else {}
+        )
+        if not platform_settings.get("enable_id_white_list", False):
+            return True
+
+        whitelist = [
+            str(item).strip()
+            for item in platform_settings.get("id_whitelist", [])
+            if str(item).strip()
+        ]
+        if not whitelist or event.get_platform_name() == "webchat":
+            return True
+
+        if platform_settings.get("wl_ignore_admin_on_group", False):
+            try:
+                if (
+                    getattr(event, "role", None) == "admin"
+                    and event.get_message_type() == MessageType.GROUP_MESSAGE
+                ):
+                    return True
+            except Exception:
+                pass
+
+        try:
+            group_id = str(event.get_group_id()).strip()
+        except Exception:
+            group_id = ""
+
+        return event.unified_msg_origin in whitelist or group_id in whitelist
+
+    def filter(self, event: AstrMessageEvent, cfg) -> bool:
+        plugin = self._get_plugin()
+        if not plugin or getattr(plugin, "_terminating", False) is True:
+            return False
+        if not plugin.initializer.is_initialized:
+            return False
+        if not plugin.config_manager.get(
+            "session_manager.enable_full_group_capture", True
+        ):
+            return False
+        try:
+            if event.get_message_type() != MessageType.GROUP_MESSAGE:
+                return False
+        except Exception as exc:
+            logger.debug(f"LivingMemory 被动群消息捕获类型检查失败: {exc}")
+            return False
+
+        if not self._passes_global_whitelist(event, cfg):
+            return False
+
+        plugin._schedule_passive_group_capture(event)
+        return False

--- a/main.py
+++ b/main.py
@@ -5,13 +5,15 @@ main.py - LivingMemory 插件主文件
 
 import asyncio
 import re
+import weakref
 from collections.abc import AsyncGenerator
 from importlib import metadata as importlib_metadata
 from typing import Any
 
-from astrbot.api import logger
+from astrbot.api import logger, sp
 from astrbot.api.event import AstrMessageEvent, MessageEventResult, filter
-from astrbot.api.event.filter import PermissionType, permission_type
+from astrbot.api.event.filter import CustomFilter, PermissionType, permission_type
+from astrbot.api.platform import MessageType
 from astrbot.api.provider import LLMResponse, ProviderRequest
 from astrbot.api.star import Context, Star, StarTools, register
 
@@ -26,6 +28,8 @@ from .core.tools import MemoryMemorizeTool, MemorySearchTool
 
 _MIN_ASTRBOT_VERSION = "4.24.2"
 _ASTRBOT_DISTRIBUTION_NAMES = ("AstrBot", "astrbot")
+_SESSION_PLUGIN_NAMES = ("LivingMemory", "astrbot_plugin_livingmemory")
+_ACTIVE_PLUGIN_REF: weakref.ReferenceType | None = None
 
 
 def _parse_version(v: str) -> tuple[int, ...]:
@@ -79,6 +83,90 @@ elif _version_lt(_CURRENT_ASTRBOT_VERSION, _MIN_ASTRBOT_VERSION):
     )
 
 
+def _set_active_plugin(plugin) -> None:
+    """Track the active plugin instance for passive filter side effects."""
+    global _ACTIVE_PLUGIN_REF
+    _ACTIVE_PLUGIN_REF = weakref.ref(plugin) if plugin is not None else None
+
+
+def _get_active_plugin():
+    if _ACTIVE_PLUGIN_REF is None:
+        return None
+    return _ACTIVE_PLUGIN_REF()
+
+
+class PassiveGroupCaptureFilter(CustomFilter):
+    """Schedule group-message capture without waking AstrBot's message pipeline."""
+
+    def __init__(self, raise_error: bool = True, plugin=None, **kwargs) -> None:
+        if not isinstance(raise_error, bool) and plugin is None:
+            plugin = raise_error
+            raise_error = True
+        super().__init__(raise_error=raise_error, **kwargs)
+        self._plugin_ref = weakref.ref(plugin) if plugin is not None else None
+
+    def _get_plugin(self):
+        if self._plugin_ref is not None:
+            return self._plugin_ref()
+        return _get_active_plugin()
+
+    @staticmethod
+    def _passes_global_whitelist(event: AstrMessageEvent, cfg) -> bool:
+        platform_settings = (
+            cfg.get("platform_settings", {}) if isinstance(cfg, dict) else {}
+        )
+        if not platform_settings.get("enable_id_white_list", False):
+            return True
+
+        whitelist = [
+            str(item).strip()
+            for item in platform_settings.get("id_whitelist", [])
+            if str(item).strip()
+        ]
+        if not whitelist or event.get_platform_name() == "webchat":
+            return True
+
+        if platform_settings.get("wl_ignore_admin_on_group", False):
+            try:
+                if (
+                    getattr(event, "role", None) == "admin"
+                    and event.get_message_type() == MessageType.GROUP_MESSAGE
+                ):
+                    return True
+            except Exception:
+                pass
+
+        try:
+            group_id = str(event.get_group_id()).strip()
+        except Exception:
+            group_id = ""
+
+        return event.unified_msg_origin in whitelist or group_id in whitelist
+
+    def filter(self, event: AstrMessageEvent, cfg) -> bool:
+        plugin = self._get_plugin()
+        if not plugin or getattr(plugin, "_terminating", False) is True:
+            return False
+        if not plugin.initializer.is_initialized:
+            return False
+        if not plugin.config_manager.get(
+            "session_manager.enable_full_group_capture", True
+        ):
+            return False
+        try:
+            if event.get_message_type() != MessageType.GROUP_MESSAGE:
+                return False
+        except Exception as exc:
+            logger.debug(f"LivingMemory 被动群消息捕获类型检查失败: {exc}")
+            return False
+
+        if not self._passes_global_whitelist(event, cfg):
+            return False
+
+        plugin._schedule_passive_group_capture(event)
+        return False
+
+
 @register(
     "LivingMemory",
     "lxfight",
@@ -119,6 +207,7 @@ class LivingMemoryPlugin(Star):
         self._terminating = False
 
         self.page_api = None
+        _set_active_plugin(self)
 
         self._register_official_page_api_if_available()
 
@@ -248,6 +337,78 @@ class LivingMemoryPlugin(Star):
         # 若用户中途修改 agent_tools 开关，需要重载插件才能生效。
         self._llm_tools_registered = True
 
+    def _schedule_passive_group_capture(self, event: AstrMessageEvent) -> None:
+        """Schedule full group capture from a filter without waking the message."""
+        if self._terminating or not self.initializer.is_initialized:
+            return
+        self._create_tracked_task(self._run_passive_group_capture(event))
+
+    async def _is_session_enabled(self, session_id: str) -> bool:
+        """Mirror AstrBot's session-level shutdown check for passive capture."""
+        try:
+            session_services = await sp.get_async(
+                scope="umo",
+                scope_id=session_id,
+                key="session_service_config",
+                default={},
+            )
+        except Exception as exc:
+            logger.debug(f"[{session_id}] 读取会话总开关失败，默认允许捕获: {exc}")
+            return True
+
+        if not isinstance(session_services, dict):
+            return True
+        session_enabled = session_services.get("session_enabled")
+        return True if session_enabled is None else bool(session_enabled)
+
+    async def _is_enabled_for_session(self, session_id: str) -> bool:
+        """Mirror AstrBot session-level plugin disable checks for passive capture."""
+        try:
+            session_plugin_config = await sp.get_async(
+                scope="umo",
+                scope_id=session_id,
+                key="session_plugin_config",
+                default={},
+            )
+        except Exception as exc:
+            logger.debug(f"[{session_id}] 读取会话插件开关失败，默认允许捕获: {exc}")
+            return True
+
+        if not isinstance(session_plugin_config, dict):
+            return True
+        session_config = session_plugin_config.get(session_id, {})
+        if not isinstance(session_config, dict):
+            return True
+        disabled_plugins = session_config.get("disabled_plugins", [])
+        if not isinstance(disabled_plugins, list):
+            return True
+        return not any(name in disabled_plugins for name in _SESSION_PLUGIN_NAMES)
+
+    async def _run_passive_group_capture(self, event: AstrMessageEvent) -> None:
+        try:
+            if not await self._is_session_enabled(event.unified_msg_origin):
+                logger.debug(
+                    f"[{event.unified_msg_origin}] 当前会话已关闭，"
+                    "跳过被动群聊消息捕获"
+                )
+                return
+            if not await self._is_enabled_for_session(event.unified_msg_origin):
+                logger.debug(
+                    f"[{event.unified_msg_origin}] LivingMemory 已在当前会话禁用，"
+                    "跳过被动群聊消息捕获"
+                )
+                return
+            if not await self._ensure_runtime_components():
+                logger.debug("插件组件未就绪，跳过被动群聊消息捕获")
+                return
+            if not self.event_handler:
+                return
+            await self.event_handler.handle_all_group_messages(event)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"被动群聊消息捕获失败: {e}", exc_info=True)
+
     async def _ensure_plugin_ready(self) -> tuple[bool, str]:
         """确保插件已完成初始化并且运行期组件可用"""
         if not await self.initializer.ensure_initialized():
@@ -283,20 +444,12 @@ class LivingMemoryPlugin(Star):
 
     # ==================== 事件钩子 ====================
 
-    @filter.platform_adapter_type(filter.PlatformAdapterType.ALL)
+    @filter.custom_filter(PassiveGroupCaptureFilter, False)
     async def handle_all_group_messages(self, event: AstrMessageEvent):
-        """[Event Hook] Capture all group messages for memory storage"""
-        if not self.initializer.is_initialized:
-            return
-
-        if not await self._ensure_runtime_components():
-            logger.debug("插件组件未就绪，跳过群聊消息捕获")
-            return
-
-        if not self.event_handler:
-            return
-
-        await self.event_handler.handle_all_group_messages(event)
+        """[Passive Filter Hook] Capture group messages without waking AstrBot."""
+        # PassiveGroupCaptureFilter schedules the capture task and always returns
+        # False, so AstrBot will not invoke this handler or mark the event as wake.
+        return
 
     @filter.on_llm_request()
     async def handle_memory_recall(self, event: AstrMessageEvent, req: ProviderRequest):
@@ -542,6 +695,8 @@ class LivingMemoryPlugin(Star):
         """Cleanup logic when plugin stops"""
         logger.info("LivingMemory 插件正在停止...")
         self._terminating = True
+        if _get_active_plugin() is self:
+            _set_active_plugin(None)
 
         # 取消所有后台任务
         if self._background_tasks:

--- a/main.py
+++ b/main.py
@@ -5,15 +5,13 @@ main.py - LivingMemory 插件主文件
 
 import asyncio
 import re
-import weakref
 from collections.abc import AsyncGenerator
 from importlib import metadata as importlib_metadata
 from typing import Any
 
-from astrbot.api import logger, sp
+from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent, MessageEventResult, filter
-from astrbot.api.event.filter import CustomFilter, PermissionType, permission_type
-from astrbot.api.platform import MessageType
+from astrbot.api.event.filter import PermissionType, permission_type
 from astrbot.api.provider import LLMResponse, ProviderRequest
 from astrbot.api.star import Context, Star, StarTools, register
 
@@ -23,13 +21,16 @@ from .core.event_handler import EventHandler
 from .core.i18n_backend import init as i18n_init
 from .core.i18n_backend import t
 from .core.managers.backup_manager import BackupManager
+from .core.passive_group_capture import PassiveGroupCaptureFilter
+from .core.passive_group_capture import get_active_plugin
+from .core.passive_group_capture import is_plugin_enabled_for_session
+from .core.passive_group_capture import is_session_enabled
+from .core.passive_group_capture import set_active_plugin
 from .core.plugin_initializer import PluginInitializer
 from .core.tools import MemoryMemorizeTool, MemorySearchTool
 
 _MIN_ASTRBOT_VERSION = "4.24.2"
 _ASTRBOT_DISTRIBUTION_NAMES = ("AstrBot", "astrbot")
-_SESSION_PLUGIN_NAMES = ("LivingMemory", "astrbot_plugin_livingmemory")
-_ACTIVE_PLUGIN_REF: weakref.ReferenceType | None = None
 
 
 def _parse_version(v: str) -> tuple[int, ...]:
@@ -83,90 +84,6 @@ elif _version_lt(_CURRENT_ASTRBOT_VERSION, _MIN_ASTRBOT_VERSION):
     )
 
 
-def _set_active_plugin(plugin) -> None:
-    """Track the active plugin instance for passive filter side effects."""
-    global _ACTIVE_PLUGIN_REF
-    _ACTIVE_PLUGIN_REF = weakref.ref(plugin) if plugin is not None else None
-
-
-def _get_active_plugin():
-    if _ACTIVE_PLUGIN_REF is None:
-        return None
-    return _ACTIVE_PLUGIN_REF()
-
-
-class PassiveGroupCaptureFilter(CustomFilter):
-    """Schedule group-message capture without waking AstrBot's message pipeline."""
-
-    def __init__(self, raise_error: bool = True, plugin=None, **kwargs) -> None:
-        if not isinstance(raise_error, bool) and plugin is None:
-            plugin = raise_error
-            raise_error = True
-        super().__init__(raise_error=raise_error, **kwargs)
-        self._plugin_ref = weakref.ref(plugin) if plugin is not None else None
-
-    def _get_plugin(self):
-        if self._plugin_ref is not None:
-            return self._plugin_ref()
-        return _get_active_plugin()
-
-    @staticmethod
-    def _passes_global_whitelist(event: AstrMessageEvent, cfg) -> bool:
-        platform_settings = (
-            cfg.get("platform_settings", {}) if isinstance(cfg, dict) else {}
-        )
-        if not platform_settings.get("enable_id_white_list", False):
-            return True
-
-        whitelist = [
-            str(item).strip()
-            for item in platform_settings.get("id_whitelist", [])
-            if str(item).strip()
-        ]
-        if not whitelist or event.get_platform_name() == "webchat":
-            return True
-
-        if platform_settings.get("wl_ignore_admin_on_group", False):
-            try:
-                if (
-                    getattr(event, "role", None) == "admin"
-                    and event.get_message_type() == MessageType.GROUP_MESSAGE
-                ):
-                    return True
-            except Exception:
-                pass
-
-        try:
-            group_id = str(event.get_group_id()).strip()
-        except Exception:
-            group_id = ""
-
-        return event.unified_msg_origin in whitelist or group_id in whitelist
-
-    def filter(self, event: AstrMessageEvent, cfg) -> bool:
-        plugin = self._get_plugin()
-        if not plugin or getattr(plugin, "_terminating", False) is True:
-            return False
-        if not plugin.initializer.is_initialized:
-            return False
-        if not plugin.config_manager.get(
-            "session_manager.enable_full_group_capture", True
-        ):
-            return False
-        try:
-            if event.get_message_type() != MessageType.GROUP_MESSAGE:
-                return False
-        except Exception as exc:
-            logger.debug(f"LivingMemory 被动群消息捕获类型检查失败: {exc}")
-            return False
-
-        if not self._passes_global_whitelist(event, cfg):
-            return False
-
-        plugin._schedule_passive_group_capture(event)
-        return False
-
-
 @register(
     "LivingMemory",
     "lxfight",
@@ -207,7 +124,7 @@ class LivingMemoryPlugin(Star):
         self._terminating = False
 
         self.page_api = None
-        _set_active_plugin(self)
+        set_active_plugin(self)
 
         self._register_official_page_api_if_available()
 
@@ -343,56 +260,15 @@ class LivingMemoryPlugin(Star):
             return
         self._create_tracked_task(self._run_passive_group_capture(event))
 
-    async def _is_session_enabled(self, session_id: str) -> bool:
-        """Mirror AstrBot's session-level shutdown check for passive capture."""
-        try:
-            session_services = await sp.get_async(
-                scope="umo",
-                scope_id=session_id,
-                key="session_service_config",
-                default={},
-            )
-        except Exception as exc:
-            logger.debug(f"[{session_id}] 读取会话总开关失败，默认允许捕获: {exc}")
-            return True
-
-        if not isinstance(session_services, dict):
-            return True
-        session_enabled = session_services.get("session_enabled")
-        return True if session_enabled is None else bool(session_enabled)
-
-    async def _is_enabled_for_session(self, session_id: str) -> bool:
-        """Mirror AstrBot session-level plugin disable checks for passive capture."""
-        try:
-            session_plugin_config = await sp.get_async(
-                scope="umo",
-                scope_id=session_id,
-                key="session_plugin_config",
-                default={},
-            )
-        except Exception as exc:
-            logger.debug(f"[{session_id}] 读取会话插件开关失败，默认允许捕获: {exc}")
-            return True
-
-        if not isinstance(session_plugin_config, dict):
-            return True
-        session_config = session_plugin_config.get(session_id, {})
-        if not isinstance(session_config, dict):
-            return True
-        disabled_plugins = session_config.get("disabled_plugins", [])
-        if not isinstance(disabled_plugins, list):
-            return True
-        return not any(name in disabled_plugins for name in _SESSION_PLUGIN_NAMES)
-
     async def _run_passive_group_capture(self, event: AstrMessageEvent) -> None:
         try:
-            if not await self._is_session_enabled(event.unified_msg_origin):
+            if not await is_session_enabled(event.unified_msg_origin):
                 logger.debug(
                     f"[{event.unified_msg_origin}] 当前会话已关闭，"
                     "跳过被动群聊消息捕获"
                 )
                 return
-            if not await self._is_enabled_for_session(event.unified_msg_origin):
+            if not await is_plugin_enabled_for_session(event.unified_msg_origin):
                 logger.debug(
                     f"[{event.unified_msg_origin}] LivingMemory 已在当前会话禁用，"
                     "跳过被动群聊消息捕获"
@@ -695,8 +571,8 @@ class LivingMemoryPlugin(Star):
         """Cleanup logic when plugin stops"""
         logger.info("LivingMemory 插件正在停止...")
         self._terminating = True
-        if _get_active_plugin() is self:
-            _set_active_plugin(None)
+        if get_active_plugin() is self:
+            set_active_plugin(None)
 
         # 取消所有后台任务
         if self._background_tasks:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,19 @@ def _install_astrbot_stubs() -> None:
         def platform_adapter_type(self, *args, **kwargs):
             return lambda func: func
 
+        def custom_filter(self, *args, **kwargs):
+            return lambda func: func
+
+        def command_group(self, *args, **kwargs):
+            class _CommandGroup:
+                def __call__(self, func):
+                    return self
+
+                def command(self, *cmd_args, **cmd_kwargs):
+                    return lambda func: func
+
+            return _CommandGroup()
+
     class AstrMessageEvent:
         pass
 
@@ -152,11 +165,30 @@ def _install_astrbot_stubs() -> None:
         def __class_getitem__(cls, item):
             return cls
 
+    class TextPart:
+        def __init__(self, text=""):
+            self.text = text
+            self._no_save = False
+
+        def mark_as_temp(self):
+            self._no_save = True
+            return self
+
+        def model_dump_for_context(self):
+            return {"type": "text", "text": self.text}
+
     class AstrAgentContext:
         pass
 
     class AstrBotConfig:
         pass
+
+    class CustomFilter:
+        def __init__(self, raise_error: bool = True, **kwargs):
+            self.raise_error = raise_error
+
+        def filter(self, event, cfg):
+            return True
 
     class EmbeddingProvider:
         pass
@@ -234,6 +266,9 @@ def _install_astrbot_stubs() -> None:
     class PermissionType(Enum):
         ADMIN = "admin"
 
+    class PlatformAdapterType(Enum):
+        ALL = "all"
+
     def permission_type(*args, **kwargs):
         return lambda func: func
 
@@ -253,8 +288,11 @@ def _install_astrbot_stubs() -> None:
     event_mod.AstrMessageEvent = AstrMessageEvent
     event_mod.MessageEventResult = MessageEventResult
     event_mod.filter = _Filter()
+    event_mod.filter.PlatformAdapterType = PlatformAdapterType
 
     event_filter_mod = types.ModuleType("astrbot.api.event.filter")
+    event_filter_mod.CustomFilter = CustomFilter
+    event_filter_mod.PlatformAdapterType = PlatformAdapterType
     event_filter_mod.PermissionType = PermissionType
     event_filter_mod.permission_type = permission_type
 
@@ -282,6 +320,8 @@ def _install_astrbot_stubs() -> None:
     core_faiss_vec_mod.FaissVecDB = FaissVecDB
 
     core_agent_mod = _package("astrbot.core.agent")
+    core_agent_message_mod = types.ModuleType("astrbot.core.agent.message")
+    core_agent_message_mod.TextPart = TextPart
     core_agent_tool_mod = types.ModuleType("astrbot.core.agent.tool")
     core_agent_tool_mod.FunctionTool = FunctionTool
     core_agent_tool_mod.ToolSet = ToolSet
@@ -342,6 +382,7 @@ def _install_astrbot_stubs() -> None:
             "astrbot.core.db.vec_db.faiss_impl": core_faiss_pkg_mod,
             "astrbot.core.db.vec_db.faiss_impl.vec_db": core_faiss_vec_mod,
             "astrbot.core.agent": core_agent_mod,
+            "astrbot.core.agent.message": core_agent_message_mod,
             "astrbot.core.agent.tool": core_agent_tool_mod,
             "astrbot.core.agent.tool_executor": core_agent_executor_mod,
             "astrbot.core.agent.run_context": core_agent_run_context_mod,
@@ -380,6 +421,7 @@ def _install_astrbot_stubs() -> None:
     core_db_mod.vec_db = core_vec_db_mod
     core_vec_db_mod.faiss_impl = core_faiss_pkg_mod
     core_faiss_pkg_mod.vec_db = core_faiss_vec_mod
+    core_agent_mod.message = core_agent_message_mod
     core_agent_mod.tool = core_agent_tool_mod
     core_agent_mod.tool_executor = core_agent_executor_mod
     core_agent_mod.run_context = core_agent_run_context_mod

--- a/tests/test_group_capture_filter.py
+++ b/tests/test_group_capture_filter.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from astrbot.api.platform import MessageType
 
-from astrbot_plugin_livingmemory.main import PassiveGroupCaptureFilter
+from astrbot_plugin_livingmemory.core.passive_group_capture import (
+    PassiveGroupCaptureFilter,
+    is_plugin_enabled_for_session,
+    is_session_enabled,
+)
 
 
 class AlwaysPassFilter:
@@ -155,11 +159,13 @@ def test_passive_group_capture_filter_allows_whitelisted_group():
 
 
 def test_passive_group_capture_filter_real_registration_constructor_uses_active_plugin():
-    from astrbot_plugin_livingmemory.main import _set_active_plugin
+    from astrbot_plugin_livingmemory.core.passive_group_capture import (
+        set_active_plugin,
+    )
 
     plugin = _make_plugin()
     event = _make_event()
-    _set_active_plugin(plugin)
+    set_active_plugin(plugin)
     try:
         filter_ = PassiveGroupCaptureFilter(False)
 
@@ -167,21 +173,13 @@ def test_passive_group_capture_filter_real_registration_constructor_uses_active_
         assert _simulate_waking_check([filter_], event) is False
         plugin._schedule_passive_group_capture.assert_called_once_with(event)
     finally:
-        _set_active_plugin(None)
+        set_active_plugin(None)
 
 
 @pytest.mark.asyncio
 async def test_passive_group_capture_skips_session_disabled_plugin():
-    from astrbot_plugin_livingmemory.main import LivingMemoryPlugin
-
-    plugin = Mock(spec=LivingMemoryPlugin)
-    plugin._is_enabled_for_session = LivingMemoryPlugin._is_enabled_for_session.__get__(
-        plugin,
-        LivingMemoryPlugin,
-    )
-
     with patch(
-        "astrbot_plugin_livingmemory.main.sp.get_async",
+        "astrbot_plugin_livingmemory.core.passive_group_capture.sp.get_async",
         new=AsyncMock(
             return_value={
                 "aiocqhttp:GroupMessage:group-1": {
@@ -191,46 +189,29 @@ async def test_passive_group_capture_skips_session_disabled_plugin():
         ),
     ):
         assert (
-            await plugin._is_enabled_for_session("aiocqhttp:GroupMessage:group-1")
+            await is_plugin_enabled_for_session("aiocqhttp:GroupMessage:group-1")
             is False
         )
 
 
 @pytest.mark.asyncio
 async def test_passive_group_capture_skips_disabled_session():
-    from astrbot_plugin_livingmemory.main import LivingMemoryPlugin
-
-    plugin = Mock(spec=LivingMemoryPlugin)
-    plugin._is_session_enabled = LivingMemoryPlugin._is_session_enabled.__get__(
-        plugin,
-        LivingMemoryPlugin,
-    )
-
     with patch(
-        "astrbot_plugin_livingmemory.main.sp.get_async",
+        "astrbot_plugin_livingmemory.core.passive_group_capture.sp.get_async",
         new=AsyncMock(return_value={"session_enabled": False}),
     ):
         assert (
-            await plugin._is_session_enabled("aiocqhttp:GroupMessage:group-1")
-            is False
+            await is_session_enabled("aiocqhttp:GroupMessage:group-1") is False
         )
 
 
 @pytest.mark.asyncio
 async def test_passive_group_capture_allows_session_without_disable():
-    from astrbot_plugin_livingmemory.main import LivingMemoryPlugin
-
-    plugin = Mock(spec=LivingMemoryPlugin)
-    plugin._is_enabled_for_session = LivingMemoryPlugin._is_enabled_for_session.__get__(
-        plugin,
-        LivingMemoryPlugin,
-    )
-
     with patch(
-        "astrbot_plugin_livingmemory.main.sp.get_async",
+        "astrbot_plugin_livingmemory.core.passive_group_capture.sp.get_async",
         new=AsyncMock(return_value={}),
     ):
         assert (
-            await plugin._is_enabled_for_session("aiocqhttp:GroupMessage:group-1")
+            await is_plugin_enabled_for_session("aiocqhttp:GroupMessage:group-1")
             is True
         )

--- a/tests/test_group_capture_filter.py
+++ b/tests/test_group_capture_filter.py
@@ -1,0 +1,236 @@
+"""Regression checks for full group capture not waking ordinary messages."""
+
+from unittest.mock import Mock
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from astrbot.api.platform import MessageType
+
+from astrbot_plugin_livingmemory.main import PassiveGroupCaptureFilter
+
+
+class AlwaysPassFilter:
+    def filter(self, event, cfg):
+        return True
+
+
+def _simulate_waking_check(filters, event):
+    """Model AstrBot's key WakingCheck behavior for adapter handlers."""
+    cfg = {
+        "platform_settings": {
+            "enable_id_white_list": False,
+            "id_whitelist": [],
+        }
+    }
+    return _simulate_waking_check_with_cfg(filters, event, cfg)
+
+
+def _simulate_waking_check_with_cfg(filters, event, cfg):
+    """Model AstrBot's key WakingCheck behavior with a supplied config."""
+    is_wake = False
+    passed = True
+    for filter_ in filters:
+        if not filter_.filter(event, cfg):
+            passed = False
+            break
+    if passed:
+        is_wake = True
+        event.is_wake = True
+    return is_wake
+
+
+def _make_plugin(initialized=True, runtime_ready=True):
+    plugin = Mock()
+    plugin.initializer = Mock(is_initialized=initialized)
+    plugin.config_manager.get.return_value = True
+    plugin._schedule_passive_group_capture = Mock()
+
+    async def _ensure_runtime_components():
+        return runtime_ready
+
+    plugin._ensure_runtime_components = _ensure_runtime_components
+    return plugin
+
+
+def _make_event(message_type=MessageType.GROUP_MESSAGE):
+    event = Mock()
+    event.get_message_type.return_value = message_type
+    event.get_platform_name.return_value = "aiocqhttp"
+    event.get_group_id.return_value = "group-1"
+    event.unified_msg_origin = "aiocqhttp:GroupMessage:group-1"
+    event.is_wake = False
+    return event
+
+
+def test_old_always_pass_handler_wakes_ordinary_message():
+    event = _make_event()
+
+    assert _simulate_waking_check([AlwaysPassFilter()], event) is True
+    assert event.is_wake is True
+
+
+def test_passive_group_capture_filter_schedules_capture_without_waking():
+    plugin = _make_plugin()
+    event = _make_event()
+    filter_ = PassiveGroupCaptureFilter(plugin)
+
+    assert _simulate_waking_check([filter_], event) is False
+    assert event.is_wake is False
+    plugin._schedule_passive_group_capture.assert_called_once_with(event)
+
+
+def test_passive_group_capture_filter_ignores_private_messages():
+    plugin = _make_plugin()
+    event = _make_event(MessageType.FRIEND_MESSAGE)
+    filter_ = PassiveGroupCaptureFilter(plugin)
+
+    assert _simulate_waking_check([filter_], event) is False
+    plugin._schedule_passive_group_capture.assert_not_called()
+
+
+def test_passive_group_capture_filter_ignores_uninitialized_plugin():
+    plugin = _make_plugin(initialized=False)
+    event = _make_event()
+    filter_ = PassiveGroupCaptureFilter(plugin)
+
+    assert _simulate_waking_check([filter_], event) is False
+    plugin._schedule_passive_group_capture.assert_not_called()
+
+
+def test_passive_group_capture_filter_ignores_disabled_capture_config():
+    plugin = _make_plugin()
+    plugin.config_manager.get.return_value = False
+    event = _make_event()
+    filter_ = PassiveGroupCaptureFilter(plugin)
+
+    assert _simulate_waking_check([filter_], event) is False
+    plugin._schedule_passive_group_capture.assert_not_called()
+
+
+def test_passive_group_capture_filter_respects_global_whitelist():
+    plugin = _make_plugin()
+    event = _make_event()
+    filter_ = PassiveGroupCaptureFilter(plugin)
+    cfg = {
+        "platform_settings": {
+            "enable_id_white_list": True,
+            "id_whitelist": ["other-group"],
+        }
+    }
+
+    assert _simulate_waking_check_with_cfg([filter_], event, cfg) is False
+    plugin._schedule_passive_group_capture.assert_not_called()
+
+
+def test_passive_group_capture_filter_respects_admin_whitelist_bypass():
+    plugin = _make_plugin()
+    event = _make_event()
+    event.role = "admin"
+    filter_ = PassiveGroupCaptureFilter(plugin)
+    cfg = {
+        "platform_settings": {
+            "enable_id_white_list": True,
+            "id_whitelist": ["other-group"],
+            "wl_ignore_admin_on_group": True,
+        }
+    }
+
+    assert _simulate_waking_check_with_cfg([filter_], event, cfg) is False
+    plugin._schedule_passive_group_capture.assert_called_once_with(event)
+
+
+def test_passive_group_capture_filter_allows_whitelisted_group():
+    plugin = _make_plugin()
+    event = _make_event()
+    filter_ = PassiveGroupCaptureFilter(plugin)
+    cfg = {
+        "platform_settings": {
+            "enable_id_white_list": True,
+            "id_whitelist": ["group-1"],
+        }
+    }
+
+    assert _simulate_waking_check_with_cfg([filter_], event, cfg) is False
+    plugin._schedule_passive_group_capture.assert_called_once_with(event)
+
+
+def test_passive_group_capture_filter_real_registration_constructor_uses_active_plugin():
+    from astrbot_plugin_livingmemory.main import _set_active_plugin
+
+    plugin = _make_plugin()
+    event = _make_event()
+    _set_active_plugin(plugin)
+    try:
+        filter_ = PassiveGroupCaptureFilter(False)
+
+        assert filter_.raise_error is False
+        assert _simulate_waking_check([filter_], event) is False
+        plugin._schedule_passive_group_capture.assert_called_once_with(event)
+    finally:
+        _set_active_plugin(None)
+
+
+@pytest.mark.asyncio
+async def test_passive_group_capture_skips_session_disabled_plugin():
+    from astrbot_plugin_livingmemory.main import LivingMemoryPlugin
+
+    plugin = Mock(spec=LivingMemoryPlugin)
+    plugin._is_enabled_for_session = LivingMemoryPlugin._is_enabled_for_session.__get__(
+        plugin,
+        LivingMemoryPlugin,
+    )
+
+    with patch(
+        "astrbot_plugin_livingmemory.main.sp.get_async",
+        new=AsyncMock(
+            return_value={
+                "aiocqhttp:GroupMessage:group-1": {
+                    "disabled_plugins": ["LivingMemory"]
+                }
+            }
+        ),
+    ):
+        assert (
+            await plugin._is_enabled_for_session("aiocqhttp:GroupMessage:group-1")
+            is False
+        )
+
+
+@pytest.mark.asyncio
+async def test_passive_group_capture_skips_disabled_session():
+    from astrbot_plugin_livingmemory.main import LivingMemoryPlugin
+
+    plugin = Mock(spec=LivingMemoryPlugin)
+    plugin._is_session_enabled = LivingMemoryPlugin._is_session_enabled.__get__(
+        plugin,
+        LivingMemoryPlugin,
+    )
+
+    with patch(
+        "astrbot_plugin_livingmemory.main.sp.get_async",
+        new=AsyncMock(return_value={"session_enabled": False}),
+    ):
+        assert (
+            await plugin._is_session_enabled("aiocqhttp:GroupMessage:group-1")
+            is False
+        )
+
+
+@pytest.mark.asyncio
+async def test_passive_group_capture_allows_session_without_disable():
+    from astrbot_plugin_livingmemory.main import LivingMemoryPlugin
+
+    plugin = Mock(spec=LivingMemoryPlugin)
+    plugin._is_enabled_for_session = LivingMemoryPlugin._is_enabled_for_session.__get__(
+        plugin,
+        LivingMemoryPlugin,
+    )
+
+    with patch(
+        "astrbot_plugin_livingmemory.main.sp.get_async",
+        new=AsyncMock(return_value={}),
+    ):
+        assert (
+            await plugin._is_enabled_for_session("aiocqhttp:GroupMessage:group-1")
+            is True
+        )


### PR DESCRIPTION
## 问题说明

当前 LivingMemory 的群聊全量捕获使用了普通的 `AdapterMessageEvent` handler，并通过 `platform_adapter_type(ALL)` 让所有平台消息都能进入处理。

这个写法会和 AstrBot 的唤醒检查逻辑冲突：AstrBot 在 `WakingCheckStage` 中会检查插件 handler 的 filter，只要某个 `AdapterMessageEvent` handler 的 filter 全部通过，就会把当前消息标记为 `event.is_wake = True`。

也就是说，在开启群聊全量捕获后，普通群消息即使没有 @ 机器人、没有唤醒词，也可能因为 LivingMemory 的全量捕获 handler 被 AstrBot 当成“命中了插件”，从而被错误地标记为唤醒。

这个根因也可以解释此前群聊里反馈过的相关现象：看起来只是正常聊天的消息，在开启全量群聊捕获后，可能会被 AstrBot 当成一次插件触发来处理。问题不一定每次都表现为直接回复，但它会让普通群消息进入错误的唤醒状态。

实际反馈里还出现过 agent 处理阶段的 `sqlite3.OperationalError: database is locked`。这个 PR 不把它直接当成同一个问题处理，但误唤醒会让普通群消息更容易异常进入 agent/LLM 流程，同时全量捕获也会写入会话数据库，因此会增加并发写库和锁冲突的风险。本次修复先阻断这条错误触发路径。

这个问题平时不一定明显，因为 LivingMemory 本身只是想静默记录消息，不一定每次都会直接产生回复。但它破坏了 AstrBot 对“普通群消息”和“真正唤醒消息”的区分，在群聊里会带来比较严重的使用风险：

- 普通群消息可能被错误地进入唤醒后的插件处理流程。
- 其他依赖 `event.is_wake` 或激活 handler 状态的逻辑可能被误触发。
- 群聊全量捕获本应是后台记忆能力，不应该改变 AstrBot 对消息是否被唤醒的判断。
- 如果会话已关闭、当前会话禁用了插件，或者全局白名单不允许，后台捕获也不应该绕过 AstrBot 的会话控制继续写入。

## 修复内容

- 新增 `PassiveGroupCaptureFilter`，用于被动捕获群聊消息。
- 过滤器在满足条件时只负责调度后台捕获任务，然后固定返回 `False`。
- 这样 LivingMemory 仍然可以记录普通群消息，但不会让 AstrBot 把这条消息标记为唤醒。
- 被动捕获前补齐 AstrBot 侧的关键限制：
  - 尊重 `session_manager.enable_full_group_capture`。
  - 只处理群聊消息。
  - 尊重全局 ID 白名单。
  - 兼容 `wl_ignore_admin_on_group` 管理员群聊白名单豁免。
  - 尊重 AstrBot 会话总开关。
  - 尊重当前会话内插件禁用配置。
- 插件停止时清理 active plugin 引用，避免停止后的被动过滤器继续调度捕获。
- 补充回归测试，覆盖普通群消息不再唤醒、仍可调度捕获，以及白名单、会话禁用、插件禁用等边界。

## 验证结果

已通过：

```text
pytest -q -s tests/test_group_capture_filter.py tests/test_event_handler.py tests/test_event_handler_reliability.py tests/test_main_tools.py
```

结果：

```text
65 passed
```

同时已通过：

```text
python -m py_compile main.py tests/conftest.py tests/test_group_capture_filter.py
git diff --check -- main.py tests/conftest.py tests/test_group_capture_filter.py
```

## 说明

这次改动只调整群聊全量捕获的触发方式，不改变记忆召回和 LLM 注入链路。

用户正常 @ 机器人、使用唤醒词，或者其他插件正常发起 LLM 请求时，LivingMemory 的 `on_llm_request` 记忆注入和 `on_llm_response` 回复记录仍会按原逻辑工作。
