### PR TITLE
fix: accept extra after-message hook args

### DIFF
--- a/main.py
+++ b/main.py
@@ -356,7 +356,7 @@ class LivingMemoryPlugin(Star):
         await self.event_handler.handle_memory_reflection(event, resp)
 
     @filter.after_message_sent()
-    async def handle_session_reset(self, event: AstrMessageEvent):
+    async def handle_session_reset(self, event: AstrMessageEvent, *_args):
         """[Event Hook] After message sent, check if plugin session context needs clearing (/reset or /new)"""
         if not event.get_extra("_clean_ltm_session", False):
             return


### PR DESCRIPTION
## Summary

- Accept extra positional arguments in the `after_message_sent` session-reset hook.
- Fixes a `TypeError` on AstrBot v4.26.5 when the hook dispatcher passes `event, *args, **kwargs`.

## Related Issues

- Closes #195

## Changes

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tests
- [ ] Configuration / release metadata

## Testing

- [ ] `uv run pytest -q`
- [x] Manual verification:

```shell
python3 -m py_compile main.py
git diff --check
```

Also verified the same patch in an AstrBot v4.26.5 Docker runtime. LivingMemory loaded successfully, initialized, and the previous `LivingMemoryPlugin.handle_session_reset() takes 2 positional arguments but 3 were given` error no longer appeared in recent logs.

## Checklist

- [x] I have searched existing issues and pull requests.
- [x] I have updated documentation or configuration schema when needed.
- [x] I have updated `metadata.yaml`, `main.py`, `CHANGELOG.md`, and version constants when this changes the released plugin version.
- [ ] I have added or updated tests for behavior changes.
