### PR TITLE
feat: add safe batch memory deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 新增
 - **召回最低重要性过滤**: 新增可选的最低重要性阈值，在统一检索出口过滤低重要性记忆 (#116)
 - **扩展上下文时间限制**: 召回查询仅拼接配置时间范围内的历史消息，避免跨话题时间间隔造成干扰 (#182)
+- **Dashboard 批量删除记忆**: 支持在当前记忆页多选并确认删除；一次批量请求内合并文档和图向量索引保存 (#192)
 - **WebUI 提示词管理页面**: 在 Dashboard 中集中管理插件所有可自定义的 prompt 模板，支持按分类浏览、编辑、保存、恢复默认，含 JSON 格式警告标识和 i18n 多语言支持
 - **PromptManager**: 提示词注册表 + 文件持久化引擎，自定义内容保存至 `data/prompts/`，内置默认不受影响；原有硬编码 prompt（system_prompt_base、system_prompt_with_persona、injection_header/footer）提取为独立模板文件
 - **提示词 API**: Page API 新增 `prompts`、`prompts/detail`、`prompts/update`、`prompts/reset`、`prompts/default` 五个路由

--- a/core/managers/graph_memory_manager.py
+++ b/core/managers/graph_memory_manager.py
@@ -81,14 +81,11 @@ class GraphMemoryManager:
         )
 
     async def batch_delete_memories(self, source_memory_ids: list[int]) -> None:
-        """Delete graph artifacts in one FAISS bulk operation per source memory."""
+        """Delete graph artifacts in one FAISS bulk operation when supported."""
         if not source_memory_ids:
             return
         memory_vec_map = await self.graph_store.batch_delete_memories(source_memory_ids)
-        for source_memory_id in source_memory_ids:
-            await self.graph_vector_retriever.delete_entries(
-                source_memory_id, memory_vec_map.get(source_memory_id, [])
-            )
+        await self.graph_vector_retriever.delete_entries_batch(memory_vec_map)
 
 
 __all__ = ["GraphMemoryManager"]

--- a/core/managers/memory_engine.py
+++ b/core/managers/memory_engine.py
@@ -1860,18 +1860,15 @@ class MemoryEngine:
                 )
                 uuid_rows = await cursor.fetchall()
                 found_ids = [int(row["id"]) for row in uuid_rows]
-                for row in uuid_rows:
-                    uuid_doc_id = row["doc_id"]
-                    if uuid_doc_id:
-                        try:
-                            await self.faiss_db.delete(uuid_doc_id)
-                        except asyncio.CancelledError:
-                            raise
-                        except Exception:
-                            logger.warning(
-                                f"[批量删除] FAISS 删除失败 (id={row['id']})",
-                                exc_info=True,
-                            )
+                if found_ids:
+                    deleted_vector_ids = await self.vector_retriever.delete_documents(
+                        found_ids
+                    )
+                    if set(deleted_vector_ids) != set(found_ids):
+                        raise RuntimeError(
+                            "批量向量删除不完整: "
+                            f"expected={found_ids}, deleted={deleted_vector_ids}"
+                        )
                 await self._advance_write_op(
                     op_id,
                     "faiss_deleted",
@@ -1884,7 +1881,9 @@ class MemoryEngine:
                     batch,
                 )
                 await self.db_connection.commit()
-                batch_deleted = int(cursor.rowcount or 0)
+                # FaissVecDB 与本引擎共享 documents 表；向量删除可能已移除
+                # 对应行，因此以删除前查到的记录数作为准确结果。
+                batch_deleted = len(found_ids)
                 await self._advance_write_op(
                     op_id,
                     "documents_deleted",

--- a/core/retrieval/graph_vector_retriever.py
+++ b/core/retrieval/graph_vector_retriever.py
@@ -6,6 +6,8 @@ import json
 from dataclasses import dataclass
 from typing import Any
 
+from .vector_retriever import delete_faiss_documents_by_ids
+
 
 @dataclass(slots=True)
 class GraphVectorResult:
@@ -137,6 +139,31 @@ class GraphVectorRetriever:
         # Compatibility with older AstrBot versions without bulk deletion.
         for vector_doc_id in vector_doc_ids:
             await self.delete_entry(vector_doc_id)
+
+    async def delete_entries_batch(
+        self,
+        entries_by_source: dict[int, list[int]],
+    ) -> None:
+        """Delete several source memories with one FAISS save when supported."""
+        vector_doc_ids = [
+            vector_doc_id
+            for source_ids in entries_by_source.values()
+            for vector_doc_id in source_ids
+        ]
+        if not vector_doc_ids:
+            return
+
+        deleted_ids = await delete_faiss_documents_by_ids(
+            self.faiss_db, vector_doc_ids
+        )
+        if deleted_ids is not None:
+            if len(deleted_ids) != len(set(vector_doc_ids)):
+                missing = sorted(set(vector_doc_ids) - set(deleted_ids))
+                raise RuntimeError(f"批量图向量删除未找到文档: {missing}")
+            return
+
+        for source_memory_id, source_ids in entries_by_source.items():
+            await self.delete_entries(source_memory_id, source_ids)
 
     async def update_metadata(
         self, vector_doc_id: int, metadata: dict[str, Any]

--- a/core/retrieval/vector_retriever.py
+++ b/core/retrieval/vector_retriever.py
@@ -24,6 +24,49 @@ class VectorResult:
     metadata: dict[str, Any]
 
 
+async def delete_faiss_documents_by_ids(
+    faiss_db,
+    doc_ids: list[int],
+) -> list[int] | None:
+    """Delete known FAISS document IDs with one index persistence operation.
+
+    Returns ``None`` when the installed AstrBot storage does not expose the
+    required bulk-capable primitives, allowing callers to use a compatibility
+    fallback.
+    """
+    if not doc_ids:
+        return []
+
+    embedding_storage = getattr(faiss_db, "embedding_storage", None)
+    document_storage = getattr(faiss_db, "document_storage", None)
+    embedding_delete = getattr(embedding_storage, "delete", None)
+    get_documents = getattr(document_storage, "get_documents", None)
+    delete_by_uuid = getattr(document_storage, "delete_document_by_doc_id", None)
+    if not (
+        callable(embedding_delete)
+        and callable(get_documents)
+        and callable(delete_by_uuid)
+    ):
+        return None
+
+    unique_ids = list(dict.fromkeys(int(doc_id) for doc_id in doc_ids))
+    documents = await get_documents(
+        metadata_filters={},
+        ids=unique_ids,
+        offset=0,
+        limit=len(unique_ids),
+    )
+    deletable = [doc for doc in documents if doc.get("doc_id")]
+    if not deletable:
+        return []
+
+    found_ids = [int(doc["id"]) for doc in deletable]
+    await embedding_delete(found_ids)
+    for document in deletable:
+        await delete_by_uuid(document["doc_id"])
+    return found_ids
+
+
 class VectorRetriever:
     """
     向量密集检索器
@@ -334,3 +377,19 @@ class VectorRetriever:
 
             logger.error(f"[向量删除] 失败 (doc_id={doc_id}): {e}", exc_info=True)
             return False
+
+    async def delete_documents(self, doc_ids: list[int]) -> list[int]:
+        """Delete multiple vector documents with one index save when supported."""
+        deleted_ids = await delete_faiss_documents_by_ids(self.faiss_db, doc_ids)
+        if deleted_ids is None:
+            deleted_ids = []
+            for doc_id in dict.fromkeys(doc_ids):
+                if await self.delete_document(doc_id):
+                    deleted_ids.append(doc_id)
+        if len(deleted_ids) != len(set(doc_ids)):
+            missing = sorted(set(doc_ids) - set(deleted_ids))
+            raise RuntimeError(f"批量向量删除未找到文档: {missing}")
+
+        for doc_id in deleted_ids:
+            self._id_cache.pop(doc_id, None)
+        return deleted_ids

--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -34,6 +34,7 @@ import {
       status: "all",
       type: "all",
       sort: "created_desc",
+      selectedIds: new Set(),
     },
     selectedMemory: null,
     isEditing: false,

--- a/pages/dashboard/i18n.js
+++ b/pages/dashboard/i18n.js
@@ -112,6 +112,10 @@
     /* ---- Delete ---- */
     "delete.confirmTitle":{ zh: "️  确认删除？", en: "️  Confirm Delete?", ru: "️  Подтвердить удаление?" },
     "delete.confirmMsg":  { zh: "即将删除 {0} 条记忆。\n此操作无法撤销！\n\n点击\"确定\"继续删除，点击\"取消\"保留。", en: "About to delete {0} memories.\nThis cannot be undone!\n\nClick OK to proceed, Cancel to keep them.", ru: "Будет удалено {0} записей.\nЭто необратимо!\n\nНажмите ОК для удаления, Отмена для сохранения." },
+    "delete.selected":    { zh: "删除所选 ({0})", en: "Delete selected ({0})", ru: "Удалить выбранные ({0})" },
+    "delete.selectedTitle":{ zh: "删除当前页中选中的记忆", en: "Delete selected memories on this page", ru: "Удалить выбранные записи на этой странице" },
+    "delete.selectAll":   { zh: "选择当前页全部记忆", en: "Select all memories on this page", ru: "Выбрать все записи на этой странице" },
+    "delete.selectOne":   { zh: "选择记忆 #{0}", en: "Select memory #{0}", ru: "Выбрать память #{0}" },
     "delete.cancelled":   { zh: "已取消删除操作", en: "Deletion cancelled", ru: "Удаление отменено" },
     "delete.deleting":    { zh: "删除中...", en: "Deleting...", ru: "Удаление..." },
     "delete.allFailed":   { zh: " 删除失败：全部 {0} 条记忆无法删除\n失败ID: {1}\n请检查日志了解详情", en: " Delete failed: all {0} memories could not be deleted\nFailed IDs: {1}", ru: " Ошибка: все {0} записей не удалены\nID: {1}" },

--- a/pages/dashboard/index.html
+++ b/pages/dashboard/index.html
@@ -155,12 +155,17 @@
                 <option value="50" data-i18n="common.perPage50">50 per page</option>
                 <option value="100" data-i18n="common.perPage100">100 per page</option>
               </select>
+              <button class="btn btn-sm btn-danger" id="mem-delete-selected" disabled data-i18n-title="delete.selectedTitle">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18M8 6V4h8v2m-9 0 1 14h8l1-14M10 11v5m4-5v5"/></svg>
+                <span id="mem-delete-selected-label" data-i18n="delete.selected">Delete selected</span>
+              </button>
             </div>
             <div class="table-container">
               <div class="table-scroll" id="memories-scroll">
               <table class="data-table" id="memories-table">
                 <thead>
                   <tr>
+                    <th class="cell-select"><input type="checkbox" id="mem-select-all" data-i18n-aria="delete.selectAll" aria-label="Select all memories on this page" /></th>
                     <th class="cell-id" data-i18n="table.id">ID</th>
                     <th class="cell-summary" data-i18n="table.summary">Summary</th>
                     <th class="cell-type" data-i18n="table.type">Type</th>
@@ -170,7 +175,7 @@
                   </tr>
                 </thead>
                 <tbody id="memories-body">
-                  <tr><td colspan="6" class="table-empty" data-i18n="table.noData">No data</td></tr>
+                  <tr><td colspan="7" class="table-empty" data-i18n="table.noData">No data</td></tr>
                 </tbody>
               </table>
               </div>

--- a/pages/dashboard/modules/api-client.js
+++ b/pages/dashboard/modules/api-client.js
@@ -67,7 +67,7 @@ export class ApiClient {
   async request(path, options = {}) {
     const method = options.method || "GET";
     const body = options.body;
-    const retries = options.retries || 2;
+    const retries = options.retries ?? 2;
 
     if (!this.bridge) {
       throw new Error(window.t ? window.t("bridge.error") : "Bridge not available");
@@ -142,7 +142,11 @@ export class ApiClient {
    * @param {Object} body - 请求体
    * @returns {Promise<any>} 响应数据
    */
-  async post(path, body = {}) {
-    return this.unwrapResponse(await this.request(path, { method: "POST", body }));
+  async post(path, body = {}, options = {}) {
+    return this.unwrapResponse(await this.request(path, {
+      method: "POST",
+      body,
+      retries: options.retries,
+    }));
   }
 }

--- a/pages/dashboard/modules/memory-page.js
+++ b/pages/dashboard/modules/memory-page.js
@@ -10,6 +10,9 @@ export class MemoryPage {
     this.state = state;
     this.api = apiClient;
     this.peek = peekPanel;
+    if (!(this.state.memory.selectedIds instanceof Set)) {
+      this.state.memory.selectedIds = new Set();
+    }
 
     // 虚拟滚动配置
     this.ROW_HEIGHT = 56;
@@ -64,6 +67,7 @@ export class MemoryPage {
           : "--",
         raw: item,
       }));
+      this.state.memory.selectedIds.clear();
 
       this.renderVirtual({ resetScroll: true });
       this.updatePagination();
@@ -109,7 +113,9 @@ export class MemoryPage {
         const impNum = Math.min(10, Math.max(0, parseFloat(imp) || 0));
         const impCls = impNum >= 7 ? "high" : impNum >= 4 ? "medium" : "low";
 
-        html += '<tr data-key="' + key + '" style="height:' + this.ROW_HEIGHT + 'px">';
+        const selected = this.state.memory.selectedIds.has(item.memory_id);
+        html += '<tr data-key="' + key + '" class="' + (selected ? 'is-selected' : '') + '" style="height:' + this.ROW_HEIGHT + 'px">';
+        html += '<td class="cell-select"><input type="checkbox" class="memory-select" data-memory-id="' + item.memory_id + '" ' + (selected ? 'checked' : '') + ' aria-label="' + esc(window.t("delete.selectOne", item.memory_id)) + '" /></td>';
         html += '<td class="cell-mono cell-id">' + item.memory_id + '</td>';
         html += '<td class="cell-summary"><div class="memory-summary-text">' + esc(item.summary || "") + '</div><div class="memory-summary-meta">' + esc(window.t("table.updated", item.updated_at || "--")) + '</div></td>';
         html += '<td class="cell-type"><span class="type-tag">' + esc(typeLabel(item.memory_type)) + '</span></td>';
@@ -124,6 +130,7 @@ export class MemoryPage {
       tbody.innerHTML = html;
       tbody.style.paddingTop = padTop + "px";
       tbody.style.paddingBottom = padBottom + "px";
+      this.updateSelectionControls();
     };
 
     // 绑定滚动事件（仅绑定一次）
@@ -142,9 +149,74 @@ export class MemoryPage {
    */
   renderEmpty() {
     const tbody = document.getElementById("memories-body");
-    tbody.innerHTML = '<tr><td colspan="6" class="table-empty">' + window.t("table.noData") + '</td></tr>';
+    tbody.innerHTML = '<tr><td colspan="7" class="table-empty">' + window.t("table.noData") + '</td></tr>';
     tbody.style.paddingTop = "0";
     tbody.style.paddingBottom = "0";
+    this.updateSelectionControls();
+  }
+
+  updateSelectionControls() {
+    const selectedIds = this.state.memory.selectedIds;
+    const pageIds = this.state.memory.items.map(item => item.memory_id);
+    const selectedOnPage = pageIds.filter(id => selectedIds.has(id)).length;
+    const selectAll = document.getElementById("mem-select-all");
+    if (selectAll) {
+      selectAll.checked = pageIds.length > 0 && selectedOnPage === pageIds.length;
+      selectAll.indeterminate = selectedOnPage > 0 && selectedOnPage < pageIds.length;
+      selectAll.disabled = pageIds.length === 0;
+    }
+
+    const deleteButton = document.getElementById("mem-delete-selected");
+    if (deleteButton) deleteButton.disabled = selectedIds.size === 0;
+    const deleteLabel = document.getElementById("mem-delete-selected-label");
+    if (deleteLabel) deleteLabel.textContent = window.t("delete.selected", selectedIds.size);
+  }
+
+  toggleAllOnPage(checked) {
+    for (const item of this.state.memory.items) {
+      if (checked) this.state.memory.selectedIds.add(item.memory_id);
+      else this.state.memory.selectedIds.delete(item.memory_id);
+    }
+    this.renderVirtual();
+  }
+
+  async deleteSelected() {
+    const ids = Array.from(this.state.memory.selectedIds);
+    if (!ids.length) return;
+
+    this.peek.open();
+    const confirmed = await this.peek.showConfirmDialog(
+      window.t("delete.confirmTitle"),
+      window.t("delete.confirmMsg", ids.length)
+    );
+    if (!confirmed) {
+      this.peek.close();
+      return;
+    }
+
+    const button = document.getElementById("mem-delete-selected");
+    if (button) button.disabled = true;
+    try {
+      const result = await this.api.post(
+        "memories/batch-delete",
+        { memory_ids: ids },
+        { retries: 0 }
+      );
+      const deleted = Number(result.deleted_count || 0);
+      if (deleted !== ids.length) {
+        const failed = ids.length - deleted;
+        this.showToast(window.t("delete.partialFailed", deleted, failed, "--"), true);
+      } else {
+        this.showToast(window.t("delete.success", deleted));
+      }
+      this.state.memory.selectedIds.clear();
+      this.peek.close();
+      await this.fetch();
+    } catch (error) {
+      this.peek.close();
+      this.showToast(error.message || window.t("delete.error"), true);
+      this.updateSelectionControls();
+    }
   }
 
   /**
@@ -178,6 +250,16 @@ export class MemoryPage {
     const tbody = document.getElementById("memories-body");
     if (tbody) {
       tbody.addEventListener("click", (e) => {
+        const checkbox = e.target.closest(".memory-select");
+        if (checkbox) {
+          const id = Number(checkbox.dataset.memoryId);
+          if (checkbox.checked) this.state.memory.selectedIds.add(id);
+          else this.state.memory.selectedIds.delete(id);
+          const row = checkbox.closest("tr");
+          if (row) row.classList.toggle("is-selected", checkbox.checked);
+          this.updateSelectionControls();
+          return;
+        }
         const tr = e.target.closest("tr");
         if (!tr || !tr.dataset.key) return;
 
@@ -185,6 +267,14 @@ export class MemoryPage {
         if (item) this.peek.renderMemory(item);
       });
     }
+
+    document.getElementById("mem-select-all").addEventListener("change", (e) => {
+      this.toggleAllOnPage(e.target.checked);
+    });
+
+    document.getElementById("mem-delete-selected").addEventListener("click", () => {
+      this.deleteSelected();
+    });
 
     // 筛选：关键词
     document.getElementById("mem-keyword").addEventListener("input", debounce(() => {

--- a/pages/dashboard/styles.css
+++ b/pages/dashboard/styles.css
@@ -624,12 +624,25 @@ body {
   background: color-mix(in srgb, var(--accent-light) 45%, var(--bg-card));
 }
 
+.data-table tbody tr.is-selected {
+  background: color-mix(in srgb, var(--accent-light) 70%, var(--bg-card));
+}
+
+.data-table .cell-select { width: 44px; text-align: center; padding-left: var(--space-2); padding-right: var(--space-2); }
 .data-table .cell-id { width: 64px; }
 .data-table .cell-summary { width: auto; min-width: 320px; }
 .data-table .cell-type { width: 100px; }
 .data-table .cell-importance { width: 140px; }
 .data-table .cell-status { width: 90px; }
 .data-table .cell-created { width: 140px; }
+
+.cell-select input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
 
 .memory-summary-text {
   color: var(--text-primary);

--- a/tests/integration/test_real_db_end_to_end.py
+++ b/tests/integration/test_real_db_end_to_end.py
@@ -192,7 +192,60 @@ async def test_graph_memory_batches_real_faiss_index_writes(
 
         await manager.delete_memory(77)
         assert len(write_paths) == 4
+
+        await manager.index_memory(78, metadata["canonical_summary"], metadata)
+        await manager.index_memory(79, metadata["canonical_summary"], metadata)
+        assert len(write_paths) == 6
+
+        await manager.batch_delete_memories([78, 79])
+        assert len(write_paths) == 7
     finally:
+        await vector_db.close()
+
+
+@pytest.mark.asyncio
+async def test_memory_batch_delete_saves_real_faiss_index_once(
+    tmp_path: Path, monkeypatch
+):
+    db_path = tmp_path / "memories.db"
+    index_path = tmp_path / "memories.index"
+    vector_db = FaissVecDB(
+        doc_store_path=str(db_path),
+        index_store_path=str(index_path),
+        embedding_provider=_DeterministicEmbeddingProvider(dim=24),
+    )
+    await vector_db.initialize()
+    engine = MemoryEngine(
+        db_path=str(db_path),
+        faiss_db=vector_db,
+        config={"graph_memory_enabled": False},
+    )
+    await engine.initialize()
+
+    first_id = await engine.add_memory("first", "s1", "p1", 0.5, {})
+    second_id = await engine.add_memory("second", "s1", "p1", 0.5, {})
+
+    write_paths: list[str] = []
+    original_write_index = vector_db.embedding_storage._write_index
+
+    def counted_write_index(index, path: str) -> None:
+        write_paths.append(path)
+        original_write_index(index, path)
+
+    monkeypatch.setattr(
+        vector_db.embedding_storage,
+        "_write_index",
+        counted_write_index,
+    )
+
+    try:
+        deleted = await engine.batch_delete_memories([first_id, second_id])
+        assert deleted == 2
+        assert len(write_paths) == 1
+        assert await engine.get_memory(first_id) is None
+        assert await engine.get_memory(second_id) is None
+    finally:
+        await engine.close()
         await vector_db.close()
 
 

--- a/tests/test_graph_memory.py
+++ b/tests/test_graph_memory.py
@@ -154,6 +154,31 @@ async def test_graph_vector_retriever_skips_empty_bulk_delete():
 
 
 @pytest.mark.asyncio
+async def test_graph_vector_retriever_batches_multiple_source_deletes():
+    document_storage = SimpleNamespace(
+        get_documents=AsyncMock(
+            return_value=[
+                {"id": 11, "doc_id": "uuid-11"},
+                {"id": 12, "doc_id": "uuid-12"},
+            ]
+        ),
+        delete_document_by_doc_id=AsyncMock(),
+    )
+    embedding_storage = SimpleNamespace(delete=AsyncMock())
+    retriever = GraphVectorRetriever(
+        SimpleNamespace(
+            document_storage=document_storage,
+            embedding_storage=embedding_storage,
+        )
+    )
+
+    await retriever.delete_entries_batch({7: [11], 8: [12]})
+
+    embedding_storage.delete.assert_awaited_once_with([11, 12])
+    assert document_storage.delete_document_by_doc_id.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_graph_memory_manager_indexes_nodes_edges_and_entries(tmp_path: Path):
     db_path = tmp_path / "graph_memory.db"
     graph_store = GraphStore(str(db_path))

--- a/tests/test_memory_engine.py
+++ b/tests/test_memory_engine.py
@@ -1385,8 +1385,8 @@ async def test_batch_delete_clears_fts_index(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_batch_delete_faiss_failure_continues(tmp_path: Path):
-    """FAISS delete 失败时不应阻断后续的 SQLite 删除。"""
+async def test_batch_delete_faiss_failure_is_marked_for_repair(tmp_path: Path):
+    """FAISS 删除失败时保留主记录，并将操作标记为可恢复。"""
     db_path = tmp_path / "batch_del_faissfail.db"
     faiss = _FakeFaissDB()
     engine = MemoryEngine(db_path=str(db_path), faiss_db=faiss, config={})
@@ -1428,14 +1428,25 @@ async def test_batch_delete_faiss_failure_continues(tmp_path: Path):
 
     faiss.delete = failing_delete
 
-    deleted = await engine.batch_delete_memories(ids)
-    assert deleted == 3
+    with pytest.raises(RuntimeError, match="批量向量删除未找到文档"):
+        await engine.batch_delete_memories(ids)
 
     if engine.db_connection is not None:
         cursor = await engine.db_connection.execute(
             "SELECT COUNT(*) FROM documents WHERE id IN (?, ?, ?)", tuple(ids)
         )
         row = await cursor.fetchone()
-        assert row[0] == 0
+        assert row[0] == 3
+
+        cursor = await engine.db_connection.execute(
+            """
+            SELECT status, step FROM memory_write_ops
+            WHERE op_type = 'batch_delete'
+            ORDER BY id DESC LIMIT 1
+            """
+        )
+        op_row = await cursor.fetchone()
+        assert op_row["status"] == "needs_repair"
+        assert op_row["step"] == "batch_delete_failed"
 
     await engine.close()

--- a/tests/test_retrieval_components.py
+++ b/tests/test_retrieval_components.py
@@ -5,7 +5,9 @@ Tests for retrieval components (BM25/RRF/Hybrid).
 import json
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock, call
 
 import aiosqlite
 import pytest
@@ -32,6 +34,35 @@ from astrbot_plugin_livingmemory.core.retrieval.rrf_fusion import (
 )
 from astrbot_plugin_livingmemory.core.retrieval.vector_retriever import VectorRetriever
 from astrbot_plugin_livingmemory.core.utils.stopwords_manager import StopwordsManager
+
+
+@pytest.mark.asyncio
+async def test_vector_retriever_bulk_delete_saves_index_once() -> None:
+    document_storage = SimpleNamespace(
+        get_documents=AsyncMock(
+            return_value=[
+                {"id": 11, "doc_id": "uuid-11"},
+                {"id": 12, "doc_id": "uuid-12"},
+            ]
+        ),
+        delete_document_by_doc_id=AsyncMock(),
+    )
+    embedding_storage = SimpleNamespace(delete=AsyncMock())
+    retriever = VectorRetriever(
+        SimpleNamespace(
+            document_storage=document_storage,
+            embedding_storage=embedding_storage,
+        )
+    )
+
+    deleted_ids = await retriever.delete_documents([11, 12])
+
+    assert deleted_ids == [11, 12]
+    embedding_storage.delete.assert_awaited_once_with([11, 12])
+    assert document_storage.delete_document_by_doc_id.await_args_list == [
+        call("uuid-11"),
+        call("uuid-12"),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add current-page selection and confirmed batch deletion to the memory dashboard.
- Use AstrBot's bulk embedding-storage deletion capability when available, with compatibility fallback.
- Keep document, BM25, FAISS, graph, and atom deletion coordinated and mark repair state on storage failure.

## Related Issues

- Closes #192

## Changes

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactor
- [x] Tests
- [ ] Configuration / release metadata

## Testing

- [ ] `uv run pytest -q` (the workspace uses AstrBot's existing virtual environment)
- [x] `/Users/lxfight/Public/vscode/AstrBot/.venv/bin/pytest -q` (604 passed)
- [x] `python3 -m compileall -q core tests`
- [x] Manual verification:
  - Select all rows and confirm the selected count.
  - Confirm one batch request contains all selected memory IDs.
  - Confirm the list refreshes and selection clears after deletion.
  - Inspect the confirmation panel and table layout in the dashboard.

## Checklist

- [x] I have searched existing issues and pull requests.
- [x] No documentation or configuration schema update is required.
- [x] This does not change the released plugin version; release metadata is intentionally unchanged.
- [x] I have added or updated tests for behavior changes.
