### PR TITLE
docs: redesign multilingual readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,6 @@ Upgrading from v1.4.0-v1.4.2? Review the [backup and migration settings](https:/
 
 [Documentation](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/) · [Releases](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/releases) · [Changelog](CHANGELOG.md) · [Issues](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/issues)
 
+Community support: [QQ group 953245617](https://qm.qq.com/cgi-bin/qm/qr?k=WdyqoP-AOEXqGAN08lOFfVSguF2EmBeO&jump_from=webapi&authKey=tPyfv90TVYSGVhbAhsAZCcSBotJuTTLf03wnn7/lQZPUkWfoQ/J8e9nkAipkOzwh) · Password: `lxfight`
+
 LivingMemory is released under the [AGPL-3.0 license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,200 +1,74 @@
 <div align="center">
 
-[中文](README_zh.md) | [English](README.md) | [Русский](README_ru.md)
+<p><a href="README_zh.md">中文</a> &nbsp;/&nbsp; <strong>English</strong> &nbsp;/&nbsp; <a href="README_ru.md">Русский</a></p>
+
+<h1>LivingMemory</h1>
+
+<p><strong>Long-term memory for AstrBot that recalls with precision and evolves with every conversation.</strong></p>
+
+<p><sub>CAPTURE &nbsp;&nbsp; RETRIEVE &nbsp;&nbsp; CONNECT &nbsp;&nbsp; EVOLVE</sub></p>
+
+<p>
+  <a href="https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/releases"><img src="https://img.shields.io/github/v/release/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory?style=flat-square&color=5f7f79" alt="Latest release"></a>
+  <img src="https://img.shields.io/badge/Python-3.10%2B-e9f1ef?style=flat-square&labelColor=263a36" alt="Python 3.10 or later">
+  <img src="https://img.shields.io/badge/AstrBot-%3E%3D%204.24.2-f3eee4?style=flat-square&labelColor=544c3d" alt="AstrBot 4.24.2 or later">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-f2e8e5?style=flat-square&labelColor=5b403a" alt="AGPL-3.0 license"></a>
+</p>
+
+<img src="docs/public/images/retrieval-flow.svg" width="100%" alt="LivingMemory dual-route retrieval flow">
 
 </div>
 
-# LivingMemory - Intelligent Long-Term Memory Plugin with Dynamic Lifecycle
+## Memory, with structure
 
-<p align="center">
-  <a href="https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/releases"><img src="https://img.shields.io/github/v/release/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory?color=76bad9" alt="Release"></a>
-  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+"></a>
-  <a href="https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/"><img src="https://img.shields.io/badge/docs-English%20%7C%20中文-3d7f8f" alt="Documentation"></a>
-  <a href="https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/stargazers"><img src="https://img.shields.io/github/stars/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory?style=social" alt="Stars"></a>
-  <a href="https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-red" alt="License AGPLv3"></a>
-</p>
+<table>
+<tr>
+<td width="33%"><strong>PRECISE RECALL</strong><br><br>BM25 and vector search run across document and graph routes, then converge through ranked fusion.</td>
+<td width="33%"><strong>LIVING CONTEXT</strong><br><br>Facts become independent memory atoms with importance, TTL, reinforcement, and temporal decay.</td>
+<td width="33%"><strong>VISIBLE SCALE</strong><br><br>Explore the complete relationship graph through a responsive canvas with communities and level of detail.</td>
+</tr>
+</table>
 
-<p align="center">
-  <a href="https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/">English Documentation</a>
-  ·
-  <a href="https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/">中文文档</a>
-</p>
+## One memory system
 
----
+| Recall | Intelligence | Control |
+| :--- | :--- | :--- |
+| **Hybrid retrieval**<br>Keyword and semantic search across two routes. | **Dual summaries**<br>Facts and persona context remain independently useful. | **Safe operations**<br>Backups, transactional deletion, and rebuild rollback. |
+| **Agent-native tools**<br>`recall_long_term_memory` and `memorize_long_term_memory`. | **Temporal graph**<br>Confidence evolves as evidence accumulates or fades. | **Focused dashboard**<br>Manage memory, debug recall, and inspect the full graph. |
 
-## Core Features
+```mermaid
+flowchart LR
+    A[Conversation] --> B[Summarize]
+    B --> C[Atomize and index]
+    C --> D[Hybrid recall]
+    D --> E[Reinforce]
+    C --> F[Decay or expire]
+    E --> C
+```
 
-- **Hybrid Retrieval**: Combines BM25 sparse retrieval and Faiss vector retrieval with RRF fusion.
-- **Dual-Route Four-Mode Retrieval**: Maintains both document and graph routes, each supporting keyword and vector retrieval before unified ranking.
-- **Intelligent Summarization**: Uses an LLM to summarize conversation history into structured memories.
-- **Dual-Channel Summarization**: Stores `canonical_summary` and `persona_summary` separately for retrieval and prompt injection.
-- **Session Isolation**: Supports persona-level and session-level memory isolation.
-- **Agent Memory Tools**: Exposes `recall_long_term_memory` and `memorize_long_term_memory` so agents can actively recall or write long-term memories when needed.
-- **Auto-Forgetting**: Cleans up stale memories based on time and importance.
-- **Memory Atomization**: Each key fact becomes an independent retrieval unit with its own TTL, decay curve, and lifecycle management.
-- **Time-Aware Graph**: Edge confidence updates dynamically via EMA as new evidence accumulates; cross-memory semantic edge merging; temporal decay in retrieval scoring.
-- **Data Safety**: Automatic backup on plugin version update, pre-migration backup, rollback on index rebuild failure, and transactional deletion.
-- **WebUI Management**: Supports the AstrBot official plugin Pages dashboard with trilingual (zh/en/ru) support and dark mode.
+## Start in three moves
 
----
+1. Install the plugin from the AstrBot plugin marketplace, or place it in `data/plugins`.
+2. Reload AstrBot and open the LivingMemory configuration page.
+3. Select the providers below; everything else has practical defaults.
 
-## Quick Start
-
-### Installation
-
-Place the plugin folder under AstrBot's `data/plugins` directory. AstrBot installs dependencies automatically.
-
-### Configuration
-
-Configure the plugin from the AstrBot plugin configuration page.
-
-**Required settings**:
-- `embedding_provider_id`: Embedding model ID. Leave empty to use the AstrBot default.
-- `llm_provider_id`: LLM model ID. Leave empty to use the AstrBot default.
-
-**Memory injection compatibility**:
-- `fake_tool_call` automatically falls back to `extra_user_content` for Gemini providers to avoid tool-message protocol incompatibility.
-- DeepSeek V4 `thinking` mode can use normal `fake_tool_call` on recent AstrBot versions. The legacy `fake_tool_call_deepseek_v4` option is kept for compatibility and automatically falls back to `fake_tool_call`.
-
-### AstrBot Version Requirement
-
-- The **AstrBot official plugin Pages dashboard** requires **AstrBot >= 4.24.2**.
-
-### Management Entry
-
-1. Open the AstrBot official WebUI.
-2. Go to `Plugins -> LivingMemory -> Pages -> dashboard`.
-
----
-
-## Commands
-
-| Command | Description |
+| Setting | Purpose |
 | :--- | :--- |
-| `/lmem status` | View memory status |
-| `/lmem search <query> [k]` | Search memories (default 5 items) |
-| `/lmem forget <id>` | Delete a specific memory |
-| `/lmem rebuild-index` | Rebuild indexes |
-| `/lmem rebuild-graph` | Rebuild graph memory indexes |
-| `/lmem webui` | View WebUI information |
-| `/lmem summarize` | Trigger immediate summarization for the current session |
-| `/lmem reset` | Reset current session memory context |
-| `/lmem cleanup [preview\|exec]` | Clean injected memory fragments from history |
-| `/lmem help` | Show help |
+| `embedding_provider_id` | Embedding model; leave empty to use the AstrBot default. |
+| `llm_provider_id` | Summarization model; leave empty to use the AstrBot default. |
 
----
+Open the visual workspace at `Plugins -> LivingMemory -> Pages -> dashboard`. Plugin Pages requires **AstrBot 4.24.2 or later**.
 
-## Architecture
+## Go deeper
 
-### Module Structure
+| Learn | Configure | Operate | Understand |
+| :--- | :--- | :--- | :--- |
+| [Quick start](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/guide/getting-started) | [Configuration](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/configuration) | [Commands](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/commands) | [Architecture](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/architecture) |
 
-```
-astrbot_plugin_livingmemory/
-├── main.py                          # Plugin registration and lifecycle management
-├── core/
-│   ├── base/                        # Base components
-│   ├── managers/                    # Core managers
-│   ├── retrieval/                   # Retrieval layer
-│   ├── validators/                  # Validators
-│   ├── plugin_initializer.py        # Plugin initializer
-│   ├── event_handler.py             # Event handler
-│   └── command_handler.py           # Command handler
-├── storage/                         # Storage layer
-├── pages/dashboard/                 # AstrBot official plugin Pages assets
-├── tests/                           # Test suite
-└── docs/                            # Documentation
-```
+Upgrading from v1.4.0-v1.4.2? Review the [backup and migration settings](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/configuration#backup-migration-and-cleanup) first.
 
-### Core Components
+## Project
 
-1. **PluginInitializer**
-   - Non-blocking initialization
-   - Provider wait and retry
-   - Automatic database migration
+[Documentation](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/) · [Releases](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/releases) · [Changelog](CHANGELOG.md) · [Issues](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/issues)
 
-2. **EventHandler**
-   - Group message capture
-   - Memory recall
-   - Memory reflection
-
-3. **Agent Memory Tools**
-   - `recall_long_term_memory`: actively recalls long-term memories, reusing current session/persona filtering settings and returning raw memory results
-   - `memorize_long_term_memory`: actively writes long-term memories, always using the current UMO and persona while reusing the automatic summarization storage format
-   - Useful for scenarios such as “do you remember”, “what did I say before”, and “please remember ...”
-
-4. **CommandHandler**
-   - Unified command responses
-   - Structured error handling
-
-5. **PluginPageApi**
-   - Registers plugin page APIs through `register_web_api`
-   - Reuses the runtime memory engine and graph components
-   - Provides memory management, recall debugging, and graph queries for `pages/dashboard`
-
-6. **ConfigManager**
-   - Centralized configuration loading
-   - Configuration validation
-   - Nested key access
-
----
-
-## Agent Memory Tools
-
-The plugin registers two LLM tools at runtime so agents can actively manage long-term memory:
-
-- `recall_long_term_memory`: actively recalls existing memories. Use it when the user asks what the bot remembers, asks about previous context, or when ambiguous references require checking history. Prefer short keywords such as topics, entities, preferences, or agreements.
-- `memorize_long_term_memory`: actively writes long-term memory. Use it when the user explicitly asks the bot to remember something, or when stable preferences, durable facts, agreements, identity details, or long-lived project context appear.
-
----
-
-## Developer Guide
-
-### Testing
-
-```bash
-# Run all tests
-pytest tests/
-
-# Run a specific test
-pytest tests/test_config_manager.py
-
-# Show coverage
-pytest --cov=core tests/
-```
-
-### Documentation
-
-- [VitePress Documentation Site](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/): Quick start, features, WebUI usage, architecture, and docs deployment.
-- [中文文档](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/): Chinese documentation site.
-
----
-
-## Data Migration (v1.4.0-v1.4.2)
-
-If you upgrade from v1.4.0-v1.4.2, old data may not migrate automatically. Manual recovery steps:
-
-1. Locate the backup file: `data/plugin_data/astrbot_plugin_livingmemory/backups/livingmemory_backup_<timestamp>.db`
-2. Move it to `data/plugin_data/astrbot_plugin_livingmemory/`
-3. Rename it to `livingmemory.db`
-4. Reload the plugin. The system will load and process the data automatically.
-
----
-
-## Changelog
-
-See [CHANGELOG.md](CHANGELOG.md).
-
----
-
-## Support
-
-- **GitHub**: [astrbot_plugin_livingmemory](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory)
-- **Issues**: [GitHub Issues](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/issues)
-- **QQ Group**: [![Join QQ Group](https://img.shields.io/badge/QQ%20Group-953245617-blue?style=flat-square&logo=tencent-qq)](https://qm.qq.com/cgi-bin/qm/qr?k=WdyqoP-AOEXqGAN08lOFfVSguF2EmBeO&jump_from=webapi&authKey=tPyfv90TVYSGVhbAhsAZCcSBotJuTTLf03wnn7/lQZPUkWfoQ/J8e9nkAipkOzwh)
-  (Password: lxfight)
-
----
-
-## License
-
-This project is licensed under AGPLv3.
+LivingMemory is released under the [AGPL-3.0 license](LICENSE).

--- a/README_ru.md
+++ b/README_ru.md
@@ -1,198 +1,74 @@
 <div align="center">
 
-[中文](README_zh.md) | [English](README.md) | [Русский](README_ru.md)
+<p><a href="README_zh.md">中文</a> &nbsp;/&nbsp; <a href="README.md">English</a> &nbsp;/&nbsp; <strong>Русский</strong></p>
+
+<h1>LivingMemory</h1>
+
+<p><strong>Долговременная память для AstrBot: точное извлечение и развитие с каждым диалогом.</strong></p>
+
+<p><sub>СОХРАНЯТЬ &nbsp;&nbsp; ИЗВЛЕКАТЬ &nbsp;&nbsp; СВЯЗЫВАТЬ &nbsp;&nbsp; РАЗВИВАТЬ</sub></p>
+
+<p>
+  <a href="https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/releases"><img src="https://img.shields.io/github/v/release/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory?style=flat-square&color=5f7f79" alt="Последний релиз"></a>
+  <img src="https://img.shields.io/badge/Python-3.10%2B-e9f1ef?style=flat-square&labelColor=263a36" alt="Python 3.10 или новее">
+  <img src="https://img.shields.io/badge/AstrBot-%3E%3D%204.24.2-f3eee4?style=flat-square&labelColor=544c3d" alt="AstrBot 4.24.2 или новее">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-f2e8e5?style=flat-square&labelColor=5b403a" alt="Лицензия AGPL-3.0"></a>
+</p>
+
+<img src="docs/public/images/retrieval-flow.svg" width="100%" alt="Двухконтурная схема извлечения LivingMemory">
 
 </div>
 
-# LivingMemory — Интеллектуальный плагин долгосрочной памяти с динамическим жизненным циклом
+## Память приобретает структуру
 
-<p align="center">
-  <a href="https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/releases"><img src="https://img.shields.io/github/v/release/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory?color=76bad9" alt="Релиз"></a>
-  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+"></a>
-  <a href="https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/"><img src="https://img.shields.io/badge/docs-English%20%7C%20中文-3d7f8f" alt="Documentation"></a>
-  <a href="https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/stargazers"><img src="https://img.shields.io/github/stars/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory?style=social" alt="Звёзды"></a>
-  <a href="https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-red" alt="Лицензия AGPLv3"></a>
-</p>
+<table>
+<tr>
+<td width="33%"><strong>ТОЧНОЕ ИЗВЛЕЧЕНИЕ</strong><br><br>BM25 и векторный поиск работают с документами и графом, а затем объединяют результаты в единый рейтинг.</td>
+<td width="33%"><strong>ЖИВОЙ КОНТЕКСТ</strong><br><br>Факты становятся независимыми атомами памяти с важностью, TTL, усилением и временным затуханием.</td>
+<td width="33%"><strong>МАСШТАБ БЕЗ СКРЫТЫХ ДАННЫХ</strong><br><br>Полный граф связей доступен на производительном холсте с сообществами и уровнями детализации.</td>
+</tr>
+</table>
 
-<p align="center">
-  <a href="https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/">English Documentation</a>
-  ·
-  <a href="https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/">中文文档</a>
-</p>
+## Единая система памяти
 
----
+| Извлечение | Интеллект | Управление |
+| :--- | :--- | :--- |
+| **Гибридный поиск**<br>Ключевые слова и семантика в двух контурах. | **Два вида сводок**<br>Факты и контекст личности сохраняют отдельную ценность. | **Безопасные операции**<br>Резервные копии, транзакционное удаление и откат. |
+| **Инструменты для Agent**<br>`recall_long_term_memory` и `memorize_long_term_memory`. | **Временной граф**<br>Достоверность связей меняется по мере накопления и затухания свидетельств. | **Сфокусированная панель**<br>Управление памятью, отладка поиска и просмотр полного графа. |
 
-## Основные возможности
+```mermaid
+flowchart LR
+    A[Диалог] --> B[Сводка]
+    B --> C[Атомизация и индекс]
+    C --> D[Гибридный поиск]
+    D --> E[Усиление]
+    C --> F[Затухание или удаление]
+    E --> C
+```
 
-- **Гибридный поиск**: Сочетание разреженного поиска BM25 и векторного поиска Faiss с алгоритмом слияния RRF
-- **Двухпутевой поиск в четырёх режимах**: Одновременно поддерживаются документный путь и графовый путь, каждый из которых поддерживает поиск по ключевым словам и векторный поиск, с последующим единым ранжированием
-- **Интеллектуальная суммаризация**: LLM автоматически обобщает историю диалогов и генерирует структурированные воспоминания
-- **Двухканальная суммаризация**: `canonical_summary` (ориентирован на факты, для поиска) и `persona_summary` (в стиле персонажа, для инъекции в промпт) хранятся раздельно
-- **Изоляция сессий**: Поддерживается изоляция памяти по персонам и сессиям
-- **Инструменты памяти Agent**: Предоставляются `recall_long_term_memory` и `memorize_long_term_memory`, позволяющие Agent при необходимости активно вспоминать или записывать долгосрочную память
-- **Автоматическое забывание**: Интеллектуальный механизм очистки на основе времени и важности
-- **Безопасность данных**: Автоматическое резервное копирование перед миграцией, откат индексов с резервной копией, транзакционная защита операций удаления
-- **Регулярное авто-бэкапирование**: Ежедневное автоматическое резервное копирование базы данных памяти с настраиваемым сроком хранения и очисткой
-- **Инъекция через поддельный вызов инструмента** (`fake_tool_call`): Новая стратегия внедрения памяти, имитирующая вызов LLM-инструмента; улучшает совместимость с режимом агента и делает контекст памяти неотличимым от реального вызова
-- **Память описаний изображений**: Автоматическое сохранение описаний изображений (полученных от AstrBot) в долгосрочную память, позволяя вспоминать визуальные диалоги
-- **Атомизация памяти**: Каждый ключевой факт становится независимой единицей поиска с собственным TTL, кривой затухания и управлением жизненным циклом
-- **Граф с учётом времени**: Уверенность рёбер динамически обновляется через EMA при накоплении новых доказательств; межпамятное семантическое слияние рёбер; временное затухание в оценке поиска
-- **3D-граф знаний в WebUI**: Интерактивная 3D-визуализация графа сущностей и связей памяти с возможностью масштабирования, вращения и просмотра узлов
-- **Резервное копирование версий**: Автоматическое резервное копирование всех файлов данных при обновлении версии плагина в каталог с меткой версии
-- **Безопасное пакетное перестроение индекса**: Перестроение больших индексов маленькими атомарными пакетами для предотвращения переполнения памяти и повреждений; автоматический откат при сбое
-- **Управление через WebUI**: Визуальный интерфейс управления памятью с поддержкой трёх языков (ZH/EN/RU) и тёмной темы
+## Три шага для запуска
 
----
+1. Установите плагин из каталога AstrBot или поместите его в `data/plugins`.
+2. Перезапустите AstrBot и откройте страницу настроек LivingMemory.
+3. Выберите два провайдера ниже; для остальных параметров заданы практичные значения.
 
-## Быстрый старт
-
-### Установка
-
-Поместите папку плагина в директорию `data/plugins` AstrBot. AstrBot автоматически установит зависимости.
-
-### Настройка
-
-Настройка осуществляется через страницу конфигурации плагина в консоли AstrBot:
-
-**Обязательные параметры**:
-- `embedding_provider_id`: ID модели векторных эмбеддингов (оставьте пустым для использования значения по умолчанию)
-- `llm_provider_id`: ID большой языковой модели (оставьте пустым для использования значения по умолчанию)
-
-Интерфейс управления доступен через официальную страницу плагина AstrBot (Плагины → LivingMemory → Pages → dashboard), без дополнительной настройки.
-
----
-
-## Команды
-
-| Команда | Описание |
+| Параметр | Назначение |
 | :--- | :--- |
-| `/lmem status` | Просмотр состояния библиотеки памяти |
-| `/lmem search <query> [k]` | Поиск воспоминаний (по умолчанию 5 результатов) |
-| `/lmem forget <id>` | Удаление конкретного воспоминания |
-| `/lmem rebuild-index` | Перестроение индексов (исправление несоответствий) |
-| `/lmem rebuild-graph` | Перестроение графовых индексов памяти (заполнение графовых данных для старых воспоминаний) |
-| `/lmem webui` | Просмотр информации о WebUI |
-| `/lmem summarize` | Запустить немедленную суммаризацию памяти для текущей сессии |
-| `/lmem reset` | Сброс контекста памяти текущей сессии |
-| `/lmem cleanup [preview\|exec]` | Очистка вставленных фрагментов памяти из истории сообщений (по умолчанию preview — пробный прогон) |
-| `/lmem help` | Показать справку |
+| `embedding_provider_id` | Модель эмбеддингов; пустое значение использует стандартную модель AstrBot. |
+| `llm_provider_id` | Модель для сводок; пустое значение использует стандартную модель AstrBot. |
 
----
+Визуальная рабочая область: `Plugins -> LivingMemory -> Pages -> dashboard`. Для Plugin Pages нужен **AstrBot 4.24.2 или новее**.
 
-## Описание архитектуры
+## Подробнее
 
-### Структура модулей
+| Начало работы | Настройка | Команды | Архитектура |
+| :--- | :--- | :--- | :--- |
+| [Краткое руководство](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/guide/getting-started) | [Конфигурация](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/configuration) | [Список команд](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/commands) | [Устройство системы](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/architecture) |
 
-```
-astrbot_plugin_livingmemory/
-├── main.py                          # Регистрация плагина и управление жизненным циклом
-├── core/
-│   ├── base/                        # Базовые компоненты (конфигурация, константы, исключения)
-│   ├── managers/                    # Основные менеджеры (MemoryEngine, ConversationManager)
-│   ├── retrieval/                   # Слой поиска (документный путь, графовый путь, слияние RRF)
-│   ├── validators/                  # Валидаторы (IndexValidator)
-│   ├── plugin_initializer.py        # Инициализатор плагина
-│   ├── event_handler.py             # Обработчик событий
-│   └── command_handler.py           # Обработчик команд
-├── storage/                         # Слой хранения (DBMigration, ConversationStore, AutoBackup)
-├── webui/                           # Веб-интерфейс управления (таблица + 3D-граф)
-├── tests/                           # Набор тестов
-└── docs/                            # Документация
-```
+Обновляетесь с v1.4.0-v1.4.2? Сначала проверьте [настройки резервного копирования и миграции](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/configuration#backup-migration-and-cleanup).
 
-### Основные компоненты
+## Проект
 
-1. **PluginInitializer**: Отвечает за инициализацию плагина
-   - Неблокирующий механизм инициализации
-   - Ожидание Provider и повторные попытки
-   - Автоматическая миграция базы данных
+[Документация](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/) · [Релизы](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/releases) · [История изменений](CHANGELOG.md) · [Сообщить о проблеме](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/issues)
 
-2. **EventHandler**: Обрабатывает события-хуки
-   - Захват сообщений групповых чатов
-   - Восстановление памяти
-   - Рефлексия памяти
-
-3. **Инструменты памяти Agent**: Предоставляют проактивное восстановление и запись памяти для режима tool loop / agent
-   - `recall_long_term_memory`: активно восстанавливает долгосрочную память, повторно используя текущие настройки фильтрации по сессии и персоне, и возвращает исходный список воспоминаний
-   - `memorize_long_term_memory`: активно записывает долгосрочную память, всегда используя текущий UMO и текущую персону, а также формат хранения автоматической суммаризации
-   - Подходит для сценариев типа «Ты ещё помнишь?», «Я говорил раньше...» и «Пожалуйста, запомни...»
-
-4. **CommandHandler**: Обрабатывает команды
-   - Унифицированный формат ответов на команды
-   - Комплексная обработка ошибок
-
-5. **FakeToolCallFormatter** (`core/utils/`): Форматирование памяти в виде поддельного вызова инструмента LLM
-   - Совместимость с режимами агента/цикла
-   - Автоматическая очистка `EventHandler` на каждом новом ходе
-
-6. **AutoBackup** (`storage/`): Фоновое резервное копирование по расписанию
-   - Ежедневные бэкапы с политикой хранения
-   - Автоматическая очистка устаревших файлов
-
-7. **ConfigManager**: Управление конфигурацией
-   - Централизованная загрузка конфигурации
-   - Валидация конфигурации
-   - Доступ к вложенным ключам
-
----
-
-## Инструменты памяти Agent
-
-Плагин регистрирует два LLM-инструмента, чтобы Agent мог активно управлять долгосрочной памятью:
-
-- `recall_long_term_memory`: активно восстанавливает существующие воспоминания. Используйте, когда пользователь спрашивает, что бот помнит, просит прежний контекст или когда неоднозначные ссылки требуют проверки истории. Предпочтительны короткие ключевые слова: темы, сущности, предпочтения, договорённости.
-- `memorize_long_term_memory`: активно записывает долгосрочную память. Используйте, когда пользователь явно просит что-то запомнить, либо когда появляются устойчивые предпочтения, долгосрочные факты, договорённости, сведения об идентичности или долгоживущий контекст проекта.
-
----
-
-## Руководство разработчика
-
-### Тестирование
-
-```bash
-# Запуск всех тестов
-pytest tests/
-
-# Запуск конкретного теста
-pytest tests/test_config_manager.py
-
-# Просмотр покрытия
-pytest --cov=core tests/
-```
-
-### Документация
-
-- [English Documentation](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/): Quick start, features, WebUI usage, architecture, and docs deployment.
-- [中文文档](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/): Chinese documentation site.
-
----
-
-## Миграция данных (v1.4.0-1.4.2)
-
-При обновлении с версий v1.4.0-1.4.2 старые данные могут не мигрировать автоматически. Шаги ручного восстановления:
-
-1. Найдите файл резервной копии: `data/plugin_data/astrbot_plugin_livingmemory/backups/livingmemory_backup_<временная метка>.db`
-2. Переместите этот файл в: `data/plugin_data/astrbot_plugin_livingmemory/`
-3. Переименуйте в: `livingmemory.db`
-4. Перезагрузите плагин — система автоматически загрузит и обработает данные
-
----
-
-## История изменений
-
-См. [CHANGELOG.md](CHANGELOG.md)
-
----
-
-## Поддержка
-
-- **GitHub**: [astrbot_plugin_livingmemory](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory)
-- **Сообщить об ошибке**: [GitHub Issues](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/issues)
-- **QQ-группа**: [![Присоединиться к QQ-группе](https://img.shields.io/badge/QQ%20Group-953245617-blue?style=flat-square&logo=tencent-qq)](https://qm.qq.com/cgi-bin/qm/qr?k=WdyqoP-AOEXqGAN08lOFfVSguF2EmBeO&jump_from=webapi&authKey=tPyfv90TVYSGVhbAhsAZCcSBotJuTTLf03wnn7/lQZPUkWfoQ/J8e9nkAipkOzwh)
-  (Пароль: lxfight)
-
----
-
-## Лицензия
-
-Этот проект распространяется под лицензией AGPLv3.
+LivingMemory распространяется по [лицензии AGPL-3.0](LICENSE).

--- a/README_ru.md
+++ b/README_ru.md
@@ -71,4 +71,6 @@ flowchart LR
 
 [Документация](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/) · [Релизы](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/releases) · [История изменений](CHANGELOG.md) · [Сообщить о проблеме](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/issues)
 
+Поддержка сообщества: [QQ-группа 953245617](https://qm.qq.com/cgi-bin/qm/qr?k=WdyqoP-AOEXqGAN08lOFfVSguF2EmBeO&jump_from=webapi&authKey=tPyfv90TVYSGVhbAhsAZCcSBotJuTTLf03wnn7/lQZPUkWfoQ/J8e9nkAipkOzwh) · Пароль: `lxfight`
+
 LivingMemory распространяется по [лицензии AGPL-3.0](LICENSE).

--- a/README_zh.md
+++ b/README_zh.md
@@ -71,4 +71,6 @@ flowchart LR
 
 [完整文档](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/) · [版本发布](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/releases) · [更新记录](CHANGELOG.md) · [问题反馈](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/issues)
 
+社区支持：[QQ 群 953245617](https://qm.qq.com/cgi-bin/qm/qr?k=WdyqoP-AOEXqGAN08lOFfVSguF2EmBeO&jump_from=webapi&authKey=tPyfv90TVYSGVhbAhsAZCcSBotJuTTLf03wnn7/lQZPUkWfoQ/J8e9nkAipkOzwh) · 口令：`lxfight`
+
 LivingMemory 使用 [AGPL-3.0 许可证](LICENSE)发布。

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,224 +1,74 @@
 <div align="center">
 
-[中文](README_zh.md) | [English](README.md) | [Русский](README_ru.md)
+<p><strong>中文</strong> &nbsp;/&nbsp; <a href="README.md">English</a> &nbsp;/&nbsp; <a href="README_ru.md">Русский</a></p>
+
+<h1>LivingMemory</h1>
+
+<p><strong>为 AstrBot 构建的长期记忆：精准召回，并在每次对话中持续演化。</strong></p>
+
+<p><sub>捕获 &nbsp;&nbsp; 检索 &nbsp;&nbsp; 连接 &nbsp;&nbsp; 演化</sub></p>
+
+<p>
+  <a href="https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/releases"><img src="https://img.shields.io/github/v/release/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory?style=flat-square&color=5f7f79" alt="最新版本"></a>
+  <img src="https://img.shields.io/badge/Python-3.10%2B-e9f1ef?style=flat-square&labelColor=263a36" alt="Python 3.10 或更高版本">
+  <img src="https://img.shields.io/badge/AstrBot-%3E%3D%204.24.2-f3eee4?style=flat-square&labelColor=544c3d" alt="AstrBot 4.24.2 或更高版本">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-f2e8e5?style=flat-square&labelColor=5b403a" alt="AGPL-3.0 许可证"></a>
+</p>
+
+<img src="docs/public/images/retrieval-flow.svg" width="100%" alt="LivingMemory 双路检索流程">
 
 </div>
 
-# LivingMemory - 动态生命周期记忆插件
+## 让记忆形成结构
 
-<p align="center">
-  <a href="https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/releases"><img src="https://img.shields.io/github/v/release/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory?color=76bad9" alt="Release"></a>
-  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+"></a>
-  <a href="https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/"><img src="https://img.shields.io/badge/docs-中文%20%7C%20English-3d7f8f" alt="Documentation"></a>
-  <a href="https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/stargazers"><img src="https://img.shields.io/github/stars/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory?style=social" alt="Stars"></a>
-  <a href="https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-red" alt="License AGPLv3"></a>
-</p>
+<table>
+<tr>
+<td width="33%"><strong>精准召回</strong><br><br>BM25 与向量检索同时覆盖文档路和图路，最终通过融合排序收敛为可靠结果。</td>
+<td width="33%"><strong>动态上下文</strong><br><br>事实被拆分为独立记忆原子，分别拥有重要度、TTL、强化机制与时间衰减。</td>
+<td width="33%"><strong>全量可见</strong><br><br>通过社区结构与多级细节，在高性能画布中探索完整的记忆关系图谱。</td>
+</tr>
+</table>
 
-<p align="center">
-  <a href="https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/">中文文档</a>
-  ·
-  <a href="https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/">English Documentation</a>
-</p>
+## 一套完整的记忆系统
 
----
+| 召回 | 智能 | 控制 |
+| :--- | :--- | :--- |
+| **混合检索**<br>关键词与语义检索覆盖两条数据路径。 | **双通道总结**<br>事实信息与人格上下文保持独立价值。 | **安全操作**<br>自动备份、事务删除与重建失败回滚。 |
+| **Agent 原生工具**<br>`recall_long_term_memory` 与 `memorize_long_term_memory`。 | **时间感知图谱**<br>关系置信度随证据累积或消退动态变化。 | **专注的管理界面**<br>管理记忆、调试召回并检查完整图谱。 |
 
-## 核心特性
+```mermaid
+flowchart LR
+    A[对话] --> B[总结]
+    B --> C[原子化与索引]
+    C --> D[混合召回]
+    D --> E[强化]
+    C --> F[衰减或过期]
+    E --> C
+```
 
-- **混合检索**: 结合 BM25 稀疏检索和 Faiss 向量检索，使用 RRF 融合算法
-- **双路四模式检索**: 同时维护文档路与图路，两边都支持关键词检索与向量检索，再统一融合排序
-- **智能总结**: 使用 LLM 自动总结对话历史，生成结构化记忆
-- **双通道总结**: `canonical_summary`（事实导向，用于检索）与 `persona_summary`（人格风格，用于注入）解耦存储
-- **会话隔离**: 支持按人格和会话隔离记忆
-- **Agent 主动回忆**: 暴露 `recall_long_term_memory` 工具，Agent 可自行选择回忆时机与关键词，将结果直接带回工具上下文
-- **自动遗忘**: 基于时间和重要性的智能清理机制
-- **数据安全**: 迁移前自动备份、索引重建带备份回滚、删除操作带事务保护
-- **定时自动备份**: 每日自动备份记忆数据库，支持保留策略和过期清理
-- **伪造工具调用注入**: 新的记忆注入策略，模拟 LLM 工具调用，兼容 Agent / Tool Loop 模式，使记忆上下文与真实召回不可区分
-- **图片转述记忆**: 自动将 AstrBot 图片转述结果存入长期记忆，支持视觉对话的召回
-- **记忆原子化系统**: 将每个关键事实提升为独立检索单元，拥有独立的存活时间 (TTL)、衰减曲线和生命周期管理
-- **时间感知图谱**: 边置信度随证据累积动态更新，跨记忆语义边合并，检索评分引入时间衰减
-- **3D 知识图谱 WebUI**: 交互式 3D 力导向图可视化记忆实体与关系，支持缩放、旋转和节点查看
-- **安全分批索引重建**: 以小批量原子方式重建大型索引，防止内存溢出和损坏；失败时自动回滚
-- **版本备份**: 插件版本更新时自动备份所有数据文件到版本标记目录，便于数据恢复
-- **WebUI 管理**: 可视化记忆管理界面，支持三语（中/英/俄）和深色模式
+## 三步开始
 
----
+1. 从 AstrBot 插件市场安装，或将插件放入 `data/plugins`。
+2. 重载 AstrBot，进入 LivingMemory 配置页面。
+3. 选择下方两个 Provider；其余配置均提供实用默认值。
 
-## 快速开始
-
-### 安装
-
-将插件文件夹放置于 AstrBot 的 `data/plugins` 目录下，AstrBot 将自动安装依赖。
-
-### 配置
-
-通过 AstrBot 控制台的插件配置页面进行配置：
-
-**必需配置**:
-- `embedding_provider_id`: 向量嵌入模型 ID（留空使用默认）
-- `llm_provider_id`: 大语言模型 ID（留空使用默认）
-
-管理界面通过 AstrBot 官方插件页面（插件 → LivingMemory → Pages → dashboard）访问，无需额外配置。
-
----
-
-## 命令
-
-| 命令 | 说明 |
+| 配置项 | 用途 |
 | :--- | :--- |
-| `/lmem status` | 查看记忆库状态 |
-| `/lmem search <query> [k]` | 搜索记忆（默认 5 条） |
-| `/lmem forget <id>` | 删除指定记忆 |
-| `/lmem rebuild-index` | 重建索引（修复索引不一致） |
-| `/lmem rebuild-graph` | 重建图记忆索引（为旧记忆回填图数据） |
-| `/lmem webui` | 查看 WebUI 信息 |
-| `/lmem summarize` | 立即触发当前会话的记忆总结 |
-| `/lmem reset` | 重置当前会话记忆上下文 |
-| `/lmem cleanup [preview\|exec]` | 清理历史消息中的记忆注入片段（默认 preview 预演） |
-| `/lmem help` | 显示帮助 |
+| `embedding_provider_id` | 嵌入模型；留空则使用 AstrBot 默认配置。 |
+| `llm_provider_id` | 总结模型；留空则使用 AstrBot 默认配置。 |
 
----
+可视化工作区入口为 `插件 -> LivingMemory -> Pages -> dashboard`。插件 Pages 需要 **AstrBot 4.24.2 或更高版本**。
 
-## 架构说明
+## 深入了解
 
-### 模块结构
+| 入门 | 配置 | 使用 | 原理 |
+| :--- | :--- | :--- | :--- |
+| [快速开始](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/guide/getting-started) | [完整配置](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/configuration) | [命令列表](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/commands) | [技术架构](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/architecture) |
 
-```
-astrbot_plugin_livingmemory/
-├── main.py                          # 插件注册和生命周期管理
-├── core/
-│   ├── base/                        # 基础组件（配置、常量、异常）
-│   ├── managers/                    # 核心管理器（MemoryEngine、ConversationManager、
-│   │                                #   GraphMemoryManager、AtomLifecycleManager、BackupManager）
-│   ├── models/                      # 数据模型（GraphNode/Edge/Entry、MemoryAtom）
-│   ├── processors/                  # 处理器（MemoryProcessor、GraphExtractor、AtomClassifier）
-│   ├── retrieval/                   # 检索层（文档路、图路、原子路、RRF 融合、双路融合）
-│   ├── validators/                  # 验证器（IndexValidator）
-│   ├── i18n_backend.py              # 后端国际化
-│   ├── plugin_initializer.py        # 插件初始化器
-│   ├── event_handler.py             # 事件处理器
-│   └── command_handler.py           # 命令处理器
-├── storage/                         # 存储层（GraphStore、AtomStore、ConversationStore、DBMigration）
-├── pages/dashboard/                 # 插件页面（表格管理 + 3D 图谱可视化）
-├── tests/                           # 测试套件
-└── docs/                            # 文档
-```
+从 v1.4.0-v1.4.2 升级？请先检查[备份、迁移与清理配置](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/configuration#备份迁移与清理)。
 
-### 核心组件
+## 项目
 
-1. **PluginInitializer**: 负责插件初始化
-   - 非阻塞初始化机制
-   - Provider等待和重试
-   - 自动数据库迁移
+[完整文档](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/) · [版本发布](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/releases) · [更新记录](CHANGELOG.md) · [问题反馈](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/issues)
 
-2. **EventHandler**: 处理事件钩子
-   - 群聊消息捕获
-   - 记忆召回
-   - 记忆反思
-
-3. **Agent 记忆工具**: 为 tool loop / agent 模式提供主动回忆能力
-   - 工具名：`recall_long_term_memory`
-   - 复用现有会话隔离和人格隔离配置
-   - 返回原始记忆列表，不额外注入 prompt
-   - 适合“你还记得吗”“我之前说过什么”“帮我回忆一下”这类场景
-
-4. **CommandHandler**: 处理命令
-   - 统一命令响应格式
-   - 完善的错误处理
-
-5. **FakeToolCallFormatter** (`core/utils/`): 将记忆格式化为伪造的 LLM 工具调用
-   - 兼容 Agent / Tool Loop 执行模式
-   - 每轮由 `EventHandler` 自动清理
-
-6. **AtomClassifier** (`core/processors/`): 规则基原子分类器
-   - 将关键事实分类为 EPISODIC/FACTUAL/RELATIONAL/PREFERENCE/PLANNED 五种类型
-   - 零额外 LLM 调用
-
-7. **AtomLifecycleManager** (`core/managers/`): 原子生命周期管理
-   - 后台周期维护（过期 / 遗忘 / 强化检测）
-   - 基于 Jaccard + CJK bigram 的跨记忆原子强化
-
-8. **BackupManager** (`core/managers/`): 版本备份管理
-   - 插件启动时检测版本变更，自动备份所有数据文件到版本标记目录
-   - 支持备份历史查询与数据恢复
-
-9. **ConfigManager**: 配置管理
-   - 集中配置加载
-   - 配置验证
-   - 嵌套键访问
-
----
-
-## Agent 主动记忆回忆
-
-除了自动记忆召回外，插件还会在运行时注册一个 LLM 工具：`recall_long_term_memory`。
-
-这个工具的特点：
-
-- Agent 可以自己决定是否回忆长期记忆，而不是只能依赖当前轮消息作为查询词
-- 工具回忆范围自动继承当前配置中的会话隔离与人格隔离设置
-- 检索结果作为工具返回进入 agent 上下文，不会再次走记忆 prompt 注入链路
-- 更适合用户要求“回忆”“想起”“之前提过什么”或当前指代不清、需要补查历史上下文的情况
-
-建议的调用策略：
-
-- 优先使用简短关键词，而不是直接复制整句用户输入
-- 优先回忆主题、实体名、偏好、约定、历史事件等高信息量词语
-- 如果第一次回忆结果不理想，可以换一个更具体或更抽象的关键词再次回忆
-
-返回结果为原始记忆列表，包含记忆内容、相关分数、重要性及会话/人格元数据，便于 agent 自行判断哪些结果真正相关
-
----
-
-## 开发者指南
-
-### 测试
-
-```bash
-# 运行所有测试
-pytest tests/
-
-# 运行特定测试
-pytest tests/test_config_manager.py
-
-# 查看覆盖率
-pytest --cov=core tests/
-```
-
-
-### 文档
-
-- [VitePress 文档站](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/): 快速开始、功能说明、WebUI 使用、技术架构和文档部署说明
-- [English Documentation](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/): English documentation site
-
----
-
-## 数据迁移（v1.4.0-1.4.2）
-
-如果您从 v1.4.0-1.4.2 版本升级，旧数据可能无法自动迁移。手动恢复步骤：
-
-1. 找到备份文件：`data/plugin_data/astrbot_plugin_livingmemory/backups/livingmemory_backup_<时间戳>.db`
-2. 将该文件移动到：`data/plugin_data/astrbot_plugin_livingmemory/`
-3. 重命名为：`livingmemory.db`
-4. 重载插件，系统会自动加载和处理数据
-
----
-
-## 更新记录
-
-详见 [CHANGELOG.md](CHANGELOG.md)
-
----
-
-## 支持
-
-- **GitHub**: [astrbot_plugin_livingmemory](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory)
-- **问题反馈**: [GitHub Issues](https://github.com/lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory/issues)
-- **QQ 群**: [![加入QQ群](https://img.shields.io/badge/QQ群-953245617-blue?style=flat-square&logo=tencent-qq)](https://qm.qq.com/cgi-bin/qm/qr?k=WdyqoP-AOEXqGAN08lOFfVSguF2EmBeO&jump_from=webapi&authKey=tPyfv90TVYSGVhbAhsAZCcSBotJuTTLf03wnn7/lQZPUkWfoQ/J8e9nkAipkOzwh)
-  （口令：lxfight）
-
----
-
-## 许可证
-
-本项目遵循 AGPLv3 许可证。
+LivingMemory 使用 [AGPL-3.0 许可证](LICENSE)发布。

--- a/tests/test_readme_content.py
+++ b/tests/test_readme_content.py
@@ -41,7 +41,7 @@ def test_readmes_link_languages_and_project_resources() -> None:
         "/issues",
         "qm.qq.com",
         "953245617",
-        "lxfight",
+        "`lxfight`",
         "astrbot_plugin_livingmemory",
     )
     for name, content in _read_readmes().items():

--- a/tests/test_readme_content.py
+++ b/tests/test_readme_content.py
@@ -1,0 +1,65 @@
+"""Content contracts for the multilingual project overview."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+README_NAMES = ("README.md", "README_zh.md", "README_ru.md")
+LANGUAGE_LINKS = ("README.md", "README_zh.md", "README_ru.md")
+LOCAL_IMAGE_RE = re.compile(r'<img\s+[^>]*src="([^"]+)"', re.IGNORECASE)
+EMOJI_RE = re.compile(
+    "["
+    "\U0001F1E6-\U0001F1FF"
+    "\U0001F300-\U0001FAFF"
+    "\u2600-\u26FF"
+    "\u2700-\u27BF"
+    "\uFE0F"
+    "\u20E3"
+    "]"
+)
+
+
+def _read_readmes() -> dict[str, str]:
+    return {
+        name: (ROOT / name).read_text(encoding="utf-8")
+        for name in README_NAMES
+    }
+
+
+def test_readmes_are_concise_and_emoji_free() -> None:
+    for name, content in _read_readmes().items():
+        assert len(content.splitlines()) <= 130, f"{name} is too long"
+        assert not EMOJI_RE.search(content), f"{name} contains an emoji"
+
+
+def test_readmes_link_languages_and_project_resources() -> None:
+    required = (
+        "CHANGELOG.md",
+        "LICENSE",
+        "/releases",
+        "/issues",
+        "astrbot_plugin_livingmemory",
+    )
+    for name, content in _read_readmes().items():
+        assert "<h1>LivingMemory</h1>" in content
+        for language_link in LANGUAGE_LINKS:
+            if language_link != name:
+                assert language_link in content
+        for link in required:
+            assert link in content, f"{name} is missing {link}"
+
+
+def test_readme_local_images_exist() -> None:
+    for name, content in _read_readmes().items():
+        image_sources = LOCAL_IMAGE_RE.findall(content)
+        local_sources = [src for src in image_sources if "://" not in src]
+        assert local_sources, f"{name} has no local visual asset"
+        for source in local_sources:
+            assert (ROOT / source).is_file(), f"{name} references missing {source}"
+
+
+def test_readmes_do_not_claim_a_3d_graph() -> None:
+    for name, content in _read_readmes().items():
+        outdated_claim = re.search(r"(?<![%\w])3D(?![%\w])", content)
+        assert outdated_claim is None, f"{name} contains an outdated graph claim"

--- a/tests/test_readme_content.py
+++ b/tests/test_readme_content.py
@@ -39,6 +39,9 @@ def test_readmes_link_languages_and_project_resources() -> None:
         "LICENSE",
         "/releases",
         "/issues",
+        "qm.qq.com",
+        "953245617",
+        "lxfight",
         "astrbot_plugin_livingmemory",
     )
     for name, content in _read_readmes().items():


### PR DESCRIPTION
## Summary

- Redesign the English, Chinese, and Russian READMEs around a concise, consistent visual hierarchy.
- Replace outdated graph claims with the current full-graph canvas, community, and level-of-detail capabilities.
- Preserve QQ community support details in every language.

## Related Issues

- None.

## Changes

- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Refactor
- [x] Tests
- [ ] Configuration / release metadata

## Testing

- [x] `uv run pytest -q` (626 passed)
- [x] Manual verification: rendered all three files through the GitHub Markdown API and verified headings, tables, Mermaid diagrams, and documentation links.

## Checklist

- [x] I have searched existing issues and pull requests.
- [x] I have updated documentation or configuration schema when needed.
- [x] I have updated `metadata.yaml`, `main.py`, `CHANGELOG.md`, and version constants when this changes the released plugin version. (Not applicable: no version change.)
- [x] I have added or updated tests for behavior changes.