### PR TITLE
fix: generate complete release notes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,7 +17,7 @@ jobs:
       old_version: ${{ steps.check.outputs.old_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
@@ -57,7 +57,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -67,32 +67,33 @@ jobs:
           NEW_VERSION="${{ needs.check-version.outputs.new_version }}"
           OLD_VERSION="${{ needs.check-version.outputs.old_version }}"
 
-          echo "## 🎉 Release $NEW_VERSION" > changelog.md
+          echo "## LivingMemory $NEW_VERSION" > changelog.md
           echo "" >> changelog.md
 
           # 如果有上一个版本标签，生成两个版本之间的提交日志
           if git rev-parse "$OLD_VERSION" >/dev/null 2>&1; then
-            echo "### 📝 Changes since $OLD_VERSION" >> changelog.md
+            echo "### Changes since $OLD_VERSION" >> changelog.md
             echo "" >> changelog.md
 
             # 获取提交信息并分类
-            git log "$OLD_VERSION..HEAD" --pretty=format:"%s|||%h|||%an" --no-merges | while IFS='|||' read -r subject hash author; do
+            git log "$OLD_VERSION..HEAD" --pretty=tformat:"%s%x09%h%x09%an" --no-merges | while IFS=$'\t' read -r subject hash author; do
               # 根据提交信息的前缀进行分类
-              if echo "$subject" | grep -qiE "^(feat|feature):"; then
-                echo "- ✨ **Feature**: ${subject#*: } (${hash})" >> changelog.md
-              elif echo "$subject" | grep -qiE "^fix:"; then
-                echo "- 🐛 **Fix**: ${subject#*: } (${hash})" >> changelog.md
-              elif echo "$subject" | grep -qiE "^docs:"; then
-                echo "- 📚 **Docs**: ${subject#*: } (${hash})" >> changelog.md
-              elif echo "$subject" | grep -qiE "^(refactor|style|perf|test|chore):"; then
+              commit_url="https://github.com/${{ github.repository }}/commit/$hash"
+              if echo "$subject" | grep -qiE "^(feat|feature)(\([^)]*\))?:"; then
+                echo "- **Feature**: ${subject#*: } ([${hash}](${commit_url}))" >> changelog.md
+              elif echo "$subject" | grep -qiE "^fix(\([^)]*\))?:"; then
+                echo "- **Fix**: ${subject#*: } ([${hash}](${commit_url}))" >> changelog.md
+              elif echo "$subject" | grep -qiE "^docs(\([^)]*\))?:"; then
+                echo "- **Docs**: ${subject#*: } ([${hash}](${commit_url}))" >> changelog.md
+              elif echo "$subject" | grep -qiE "^(refactor|style|perf|test|chore)(\([^)]*\))?:"; then
                 prefix=$(echo "$subject" | cut -d: -f1)
-                echo "- 🔧 **${prefix^}**: ${subject#*: } (${hash})" >> changelog.md
+                echo "- **${prefix^}**: ${subject#*: } ([${hash}](${commit_url}))" >> changelog.md
               else
-                echo "- 📌 $subject (${hash})" >> changelog.md
+                echo "- $subject ([${hash}](${commit_url}))" >> changelog.md
               fi
             done
           else
-            echo "### 📝 Changes" >> changelog.md
+            echo "### Changes" >> changelog.md
             echo "" >> changelog.md
             echo "Initial release or no previous version tag found." >> changelog.md
             echo "" >> changelog.md
@@ -105,10 +106,10 @@ jobs:
           echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/$OLD_VERSION...$NEW_VERSION" >> changelog.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.check-version.outputs.new_version }}
-          name: Release ${{ needs.check-version.outputs.new_version }}
+          name: LivingMemory ${{ needs.check-version.outputs.new_version }}
           body_path: changelog.md
           draft: false
           prerelease: false
@@ -118,5 +119,5 @@ jobs:
 
       - name: Notify release created
         run: |
-          echo "✅ Release ${{ needs.check-version.outputs.new_version }} has been created successfully!"
-          echo "🔗 View release at: https://github.com/${{ github.repository }}/releases/tag/${{ needs.check-version.outputs.new_version }}"
+          echo "Release ${{ needs.check-version.outputs.new_version }} has been created successfully."
+          echo "View release at: https://github.com/${{ github.repository }}/releases/tag/${{ needs.check-version.outputs.new_version }}"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,32 @@
+"""Release workflow contract tests."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "auto-release.yml"
+
+
+def test_release_notes_keep_hashes_and_final_commit() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert '--pretty=tformat:"%s%x09%h%x09%an"' in workflow
+    assert "while IFS=$'\\t' read -r subject hash author" in workflow
+    assert "[${hash}](${commit_url})" in workflow
+    assert "IFS='|||'" not in workflow
+
+
+def test_release_copy_has_no_emoji_and_uses_current_actions() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "actions/checkout@v5" in workflow
+    assert "softprops/action-gh-release@v2" in workflow
+    assert "🎉" not in workflow
+    assert "📝" not in workflow
+    assert "✨" not in workflow
+    assert "🐛" not in workflow
+    assert "📚" not in workflow
+    assert "🔧" not in workflow
+    assert "📌" not in workflow
+    assert "✅" not in workflow
+    assert "🔗" not in workflow


### PR DESCRIPTION
## Summary

- Preserve every commit and its hash when generating automatic release notes.
- Remove emoji from generated release copy and link each short hash to its commit.
- Upgrade the checkout and release actions to their current major versions.

## Related Issues

- Follow-up to the release-note defect observed during the 2.5.0 workflow run.

## Changes

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Tests
- [x] Configuration / release metadata

## Testing

- [x] `uv run pytest -q` (688 passed)
- [x] `uv run pytest -q tests/test_release_workflow.py` (2 passed)
- [x] Ruff check for the new workflow test
- [x] YAML parsing
- [x] Simulated `2.4.1..2.5.0` log parsing retains all five commits, including #216, with hashes and authors
- [x] `git diff --check`
- [ ] Manual verification: the workflow is only triggered by a future `metadata.yaml` version change.

## Checklist

- [x] I have searched existing issues and pull requests.
- [x] I have updated documentation or configuration schema when needed.
- [x] I have updated `metadata.yaml`, `main.py`, `CHANGELOG.md`, and version constants when this changes the released plugin version. This fix does not change the plugin version.
- [x] I have added or updated tests for behavior changes.
