### PR TITLE
fix(index): make large index rebuilds non-blocking and recoverable

### DIFF
--- a/core/command_handler.py
+++ b/core/command_handler.py
@@ -114,6 +114,17 @@ class CommandHandler:
                 db_size=db_size,
             )
 
+            maintenance = stats.get("index_maintenance") or {}
+            maintenance_state = str(maintenance.get("state") or "idle")
+            if maintenance_state not in {"idle", "ready"}:
+                message += t(
+                    "status.index_maintenance",
+                    state=maintenance_state,
+                    current=int(maintenance.get("current", 0) or 0),
+                    total=int(maintenance.get("total", 0) or 0),
+                    message=str(maintenance.get("message") or ""),
+                )
+
             yield event.plain_result(message)
         except Exception as e:
             logger.error(f"获取状态失败: {e}", exc_info=True)

--- a/core/i18n/en.json
+++ b/core/i18n/en.json
@@ -27,7 +27,8 @@
   },
   "status": {
     "action_name": "Status fetch",
-    "report": "LivingMemory Status Report\n\nTotal memories: {total}\nSessions: {session_count}\nLast update: {last_update}\nDatabase size: {db_size:.2f} MB\n\nAvailable operations:\n- /lmem search <keyword>"
+    "report": "LivingMemory Status Report\n\nTotal memories: {total}\nSessions: {session_count}\nLast update: {last_update}\nDatabase size: {db_size:.2f} MB\n\nAvailable operations:\n- /lmem search <keyword>",
+    "index_maintenance": "\n\nIndex maintenance: {state} ({current}/{total})\n{message}"
   },
   "search": {
     "action_name": "Search",

--- a/core/i18n/ru.json
+++ b/core/i18n/ru.json
@@ -27,7 +27,8 @@
   },
   "status": {
     "action_name": "Получение статуса",
-    "report": "Отчёт о состоянии LivingMemory\n\nВсего памяти: {total}\nСессий: {session_count}\nПоследнее обновление: {last_update}\nРазмер БД: {db_size:.2f} MB\n\nДоступные операции:\n- /lmem search <ключевое слово>"
+    "report": "Отчёт о состоянии LivingMemory\n\nВсего памяти: {total}\nСессий: {session_count}\nПоследнее обновление: {last_update}\nРазмер БД: {db_size:.2f} MB\n\nДоступные операции:\n- /lmem search <ключевое слово>",
+    "index_maintenance": "\n\nОбслуживание индекса: {state} ({current}/{total})\n{message}"
   },
   "search": {
     "action_name": "Поиск",

--- a/core/i18n/zh.json
+++ b/core/i18n/zh.json
@@ -27,7 +27,8 @@
   },
   "status": {
     "action_name": "获取状态",
-    "report": "LivingMemory 状态报告\n\n总记忆数: {total}\n会话数: {session_count}\n最后更新: {last_update}\n数据库大小: {db_size:.2f} MB\n\n可用操作:\n- /lmem search <关键词>"
+    "report": "LivingMemory 状态报告\n\n总记忆数: {total}\n会话数: {session_count}\n最后更新: {last_update}\n数据库大小: {db_size:.2f} MB\n\n可用操作:\n- /lmem search <关键词>",
+    "index_maintenance": "\n\n索引维护: {state} ({current}/{total})\n{message}"
   },
   "search": {
     "action_name": "搜索",

--- a/core/managers/graph_memory_manager.py
+++ b/core/managers/graph_memory_manager.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
+import shutil
+import tempfile
+from collections.abc import AsyncIterable
+from pathlib import Path
 from typing import Any
+
+from astrbot.api import logger
 
 from ...storage.graph_store import GraphStore
 from ..models.graph_models import GraphEntry
@@ -22,6 +29,11 @@ class GraphMemoryManager:
         self.graph_store = graph_store
         self.graph_vector_retriever = graph_vector_retriever
         self.graph_extractor = graph_extractor
+        self._rebuild_gate = asyncio.Lock()
+        self._rebuild_active = False
+        self._rebuild_delta: dict[
+            int, tuple[str, dict[str, Any] | None, list | None] | None
+        ] = {}
 
     async def index_memory(
         self,
@@ -35,7 +47,24 @@ class GraphMemoryManager:
         When atoms are provided, each atom independently contributes
         nodes/edges/entries with per-atom confidence scores.
         """
-        await self.delete_memory(source_memory_id)
+        async with self._rebuild_gate:
+            if self._rebuild_active:
+                self._rebuild_delta[int(source_memory_id)] = (
+                    content,
+                    metadata,
+                    atoms,
+                )
+                return
+        await self._index_memory_now(source_memory_id, content, metadata, atoms)
+
+    async def _index_memory_now(
+        self,
+        source_memory_id: int,
+        content: str,
+        metadata: dict[str, Any] | None,
+        atoms: list | None = None,
+    ) -> None:
+        await self._delete_memory_now(source_memory_id)
 
         entries, entry_ids = await self._store_graph_structure(
             source_memory_id,
@@ -88,6 +117,13 @@ class GraphMemoryManager:
 
     async def delete_memory(self, source_memory_id: int) -> None:
         """Delete graph artifacts belonging to one source memory."""
+        async with self._rebuild_gate:
+            if self._rebuild_active:
+                self._rebuild_delta[int(source_memory_id)] = None
+                return
+        await self._delete_memory_now(source_memory_id)
+
+    async def _delete_memory_now(self, source_memory_id: int) -> None:
         vector_doc_ids = await self.graph_store.delete_memory(source_memory_id)
         await self.graph_vector_retriever.delete_entries(
             source_memory_id, vector_doc_ids
@@ -97,6 +133,11 @@ class GraphMemoryManager:
         """Delete graph artifacts in one FAISS bulk operation when supported."""
         if not source_memory_ids:
             return
+        async with self._rebuild_gate:
+            if self._rebuild_active:
+                for source_memory_id in source_memory_ids:
+                    self._rebuild_delta[int(source_memory_id)] = None
+                return
         memory_vec_map = await self.graph_store.batch_delete_memories(source_memory_ids)
         await self.graph_vector_retriever.delete_entries_batch(memory_vec_map)
 
@@ -104,45 +145,199 @@ class GraphMemoryManager:
         self,
         memories: list[tuple[int, str, dict[str, Any]]],
     ) -> dict[str, int]:
-        """Rebuild all graph artifacts with at most two FAISS saves."""
-        known_vector_doc_ids = await self.graph_store.clear_all()
-        await self.graph_vector_retriever.clear_all(known_vector_doc_ids)
+        """Compatibility wrapper for callers that already materialized memories."""
 
-        entry_groups: list[list[tuple[str, dict[str, Any]]]] = []
-        representative_entry_ids: list[int] = []
+        async def batches():
+            yield memories
+
+        return await self.rebuild_memory_batches(batches())
+
+    async def rebuild_memory_batches(
+        self,
+        memory_batches: AsyncIterable[list[tuple[int, str, dict[str, Any]]]],
+        *,
+        vector_batch_size: int = 100,
+    ) -> dict[str, int]:
+        """Build graph data in shadow storage and atomically switch when complete."""
+        async with self._rebuild_gate:
+            if self._rebuild_active:
+                raise RuntimeError("graph rebuild already in progress")
+            self._rebuild_active = True
+            self._rebuild_delta.clear()
+
+        temp_dir = Path(tempfile.mkdtemp(prefix="livingmemory_graph_rebuild_"))
+        shadow_store = GraphStore(str(temp_dir / "graph.db"))
+        shadow_manager = GraphMemoryManager(
+            shadow_store,
+            self.graph_vector_retriever,
+            self.graph_extractor,
+        )
+        new_vector_doc_ids: dict[int, set[int]] = {}
+        old_vector_doc_ids = await self.graph_store.list_vector_doc_ids_by_source()
         rebuilt = 0
         skipped = 0
+        switched = False
 
-        for source_memory_id, content, metadata in memories:
-            if not content.strip():
-                skipped += 1
-                continue
-            entries, entry_ids = await self._store_graph_structure(
-                source_memory_id,
-                content,
-                metadata,
+        async def remove_shadow_vectors(
+            source_memory_id: int, vector_doc_ids: list[int]
+        ) -> None:
+            known_ids = new_vector_doc_ids.get(int(source_memory_id), set())
+            ids = [
+                int(vector_doc_id)
+                for vector_doc_id in vector_doc_ids
+                if int(vector_doc_id) in known_ids
+            ]
+            if not ids:
+                return
+            await self.graph_vector_retriever.delete_entries_batch(
+                {int(source_memory_id): ids}
             )
-            if not entries:
-                skipped += 1
-                continue
-            entry_groups.append(
-                [(entry.content, dict(entry.metadata)) for entry in entries]
-            )
-            representative_entry_ids.append(entry_ids[0])
-            rebuilt += 1
+            known_ids.difference_update(ids)
+            if not known_ids:
+                new_vector_doc_ids.pop(int(source_memory_id), None)
 
-        vector_doc_ids = await self.graph_vector_retriever.add_memory_entries_batch(
-            entry_groups
-        )
-        if len(vector_doc_ids) != len(representative_entry_ids):
-            raise RuntimeError(
-                "graph vector id count mismatch: "
-                f"ids={len(vector_doc_ids)}, memories={len(representative_entry_ids)}"
-            )
-        await self.graph_store.update_entry_vector_doc_ids(
-            dict(zip(representative_entry_ids, vector_doc_ids, strict=True))
-        )
-        return {"rebuilt": rebuilt, "skipped": skipped}
+        async def apply_shadow_delta(
+            delta: dict[int, tuple[str, dict[str, Any] | None, list | None] | None],
+        ) -> None:
+            for source_memory_id, payload in delta.items():
+                replaced_vector_ids = await shadow_store.delete_memory(source_memory_id)
+                await remove_shadow_vectors(source_memory_id, replaced_vector_ids)
+                if payload is None:
+                    continue
+                content, metadata, atoms = payload
+                if not content.strip():
+                    continue
+                entries, entry_ids = await shadow_manager._store_graph_structure(
+                    source_memory_id,
+                    content,
+                    metadata,
+                    atoms,
+                )
+                if not entries:
+                    continue
+                vector_doc_id = (
+                    await self.graph_vector_retriever.add_memory_entries_batch(
+                        [[(entry.content, dict(entry.metadata)) for entry in entries]]
+                    )
+                )[0]
+                new_vector_doc_ids.setdefault(int(source_memory_id), set()).add(
+                    int(vector_doc_id)
+                )
+                await shadow_store.update_entry_vector_doc_ids(
+                    {entry_ids[0]: int(vector_doc_id)}
+                )
+
+        try:
+            await shadow_store.initialize()
+            async for memories in memory_batches:
+                for source_memory_id, content, metadata in memories:
+                    if not content.strip():
+                        skipped += 1
+                        continue
+                    entries, _entry_ids = await shadow_manager._store_graph_structure(
+                        source_memory_id,
+                        content,
+                        metadata,
+                    )
+                    if entries:
+                        rebuilt += 1
+                    else:
+                        skipped += 1
+
+            async for groups in shadow_store.iter_memory_entry_groups(
+                max(1, int(vector_batch_size))
+            ):
+                entry_groups = [entries for _, _, entries in groups]
+                vector_doc_ids = (
+                    await self.graph_vector_retriever.add_memory_entries_batch(
+                        entry_groups
+                    )
+                )
+                if len(vector_doc_ids) != len(groups):
+                    raise RuntimeError(
+                        "graph vector id count mismatch: "
+                        f"ids={len(vector_doc_ids)}, memories={len(groups)}"
+                    )
+                for (source_memory_id, _, _), vector_doc_id in zip(
+                    groups, vector_doc_ids, strict=True
+                ):
+                    new_vector_doc_ids.setdefault(int(source_memory_id), set()).add(
+                        int(vector_doc_id)
+                    )
+                await shadow_store.update_entry_vector_doc_ids(
+                    {
+                        representative_entry_id: int(vector_doc_id)
+                        for (_, representative_entry_id, _), vector_doc_id in zip(
+                            groups, vector_doc_ids, strict=True
+                        )
+                    }
+                )
+
+            while True:
+                async with self._rebuild_gate:
+                    if self._rebuild_delta:
+                        pending_delta = dict(self._rebuild_delta)
+                        self._rebuild_delta.clear()
+                    else:
+                        switch_task = asyncio.create_task(
+                            self.graph_store.replace_all_from(
+                                str(temp_dir / "graph.db")
+                            )
+                        )
+                        try:
+                            await asyncio.shield(switch_task)
+                        except asyncio.CancelledError:
+                            # Learn whether the transaction committed before
+                            # propagating cancellation; never roll back the new
+                            # vectors after a successful table switch.
+                            await switch_task
+                            switched = True
+                            self._rebuild_active = False
+                            raise
+                        switched = True
+                        self._rebuild_active = False
+                        break
+                await apply_shadow_delta(pending_delta)
+
+            if old_vector_doc_ids:
+                try:
+                    await self.graph_vector_retriever.delete_entries_batch(
+                        old_vector_doc_ids
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    # The graph tables already reference the new generation. Old
+                    # vectors are redundant but harmless and can be cleaned later.
+                    logger.warning(
+                        "图谱已切换，但旧图向量清理失败；保留新一代索引",
+                        exc_info=True,
+                    )
+            return {"rebuilt": rebuilt, "skipped": skipped}
+        except BaseException:
+            if not switched and new_vector_doc_ids:
+                try:
+                    await self.graph_vector_retriever.delete_entries_batch(
+                        {
+                            source_memory_id: sorted(vector_doc_ids)
+                            for source_memory_id, vector_doc_ids in new_vector_doc_ids.items()
+                        }
+                    )
+                except Exception:
+                    pass
+            if not switched:
+                async with self._rebuild_gate:
+                    pending_delta = dict(self._rebuild_delta)
+                    self._rebuild_delta.clear()
+                    self._rebuild_active = False
+                for source_memory_id, payload in pending_delta.items():
+                    if payload is None:
+                        await self._delete_memory_now(source_memory_id)
+                    else:
+                        await self._index_memory_now(source_memory_id, *payload)
+            raise
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 __all__ = ["GraphMemoryManager"]

--- a/core/managers/memory_engine.py
+++ b/core/managers/memory_engine.py
@@ -153,6 +153,12 @@ class MemoryEngine:
             self.config.get("write_op_repair_enabled", True)
         )
         self._write_op_max_retries = int(self.config.get("write_op_max_retries", 3))
+        self.index_maintenance_status: dict[str, Any] = {
+            "state": "idle",
+            "current": 0,
+            "total": 0,
+            "message": "",
+        }
 
     async def initialize(self):
         """
@@ -2825,6 +2831,7 @@ class MemoryEngine:
                 stats["graph_memory_enabled"] = True
             else:
                 stats["graph_memory_enabled"] = False
+            stats["index_maintenance"] = dict(self.index_maintenance_status)
 
             return stats
         except asyncio.CancelledError:

--- a/core/managers/memory_engine.py
+++ b/core/managers/memory_engine.py
@@ -1938,42 +1938,53 @@ class MemoryEngine:
         return success
 
     async def rebuild_graph_index(self) -> dict[str, int]:
-        """Rebuild graph-memory artifacts from stored documents."""
+        """Stream active documents into a safe graph-memory rebuild."""
         if self.graph_memory_manager is None:
             return {"rebuilt": 0, "skipped": 0}
 
-        total_count = await self.faiss_db.document_storage.count_documents(
-            metadata_filters={}
-        )
-        batch_size = 200
-        offset = 0
-        memories: list[tuple[int, str, dict[str, Any]]] = []
+        if self.db_connection is None:
+            raise RuntimeError("memory database is not initialized")
 
-        while offset < total_count:
-            docs = await self.faiss_db.document_storage.get_documents(
-                metadata_filters={},
-                limit=batch_size,
-                offset=offset,
-            )
-            if not docs:
-                break
+        async def active_memory_batches():
+            last_id = 0
+            batch_size = 200
+            while True:
+                cursor = await self.db_connection.execute(
+                    """
+                    SELECT id, text, metadata
+                    FROM documents
+                    WHERE id > ?
+                      AND COALESCE(
+                          json_extract(metadata, '$.status'), 'active'
+                      ) = 'active'
+                    ORDER BY id
+                    LIMIT ?
+                    """,
+                    (last_id, batch_size),
+                )
+                rows = await cursor.fetchall()
+                if not rows:
+                    break
 
-            for doc in docs:
-                metadata = doc.get("metadata") or {}
-                if isinstance(metadata, str):
-                    try:
-                        metadata = json.loads(metadata)
-                    except (json.JSONDecodeError, TypeError):
+                batch: list[tuple[int, str, dict[str, Any]]] = []
+                for row in rows:
+                    metadata = row["metadata"] or {}
+                    if isinstance(metadata, str):
+                        try:
+                            metadata = json.loads(metadata)
+                        except (json.JSONDecodeError, TypeError):
+                            metadata = {}
+                    elif not isinstance(metadata, dict):
                         metadata = {}
-                elif not isinstance(metadata, dict):
-                    metadata = {}
-                content = str(doc.get("text") or "")
-                memories.append((int(doc["id"]), content, metadata))
+                    batch.append((int(row["id"]), str(row["text"] or ""), metadata))
 
-            offset += batch_size
+                last_id = int(rows[-1]["id"])
+                yield batch
 
         self._invalidate_search_cache()
-        return await self.graph_memory_manager.rebuild_memories(memories)
+        return await self.graph_memory_manager.rebuild_memory_batches(
+            active_memory_batches()
+        )
 
     # ==================== 高级功能 ====================
 

--- a/core/plugin_initializer.py
+++ b/core/plugin_initializer.py
@@ -47,7 +47,11 @@ def _safe_temp_dir() -> str:
     if os.name == "nt":
         root = os.environ.get("SystemRoot", r"C:\Windows")
         temp_dir = os.path.join(root, "Temp")
-        if temp_dir.isascii() and os.path.isdir(temp_dir) and os.access(temp_dir, os.W_OK):
+        if (
+            temp_dir.isascii()
+            and os.path.isdir(temp_dir)
+            and os.access(temp_dir, os.W_OK)
+        ):
             return temp_dir
         tmp = tempfile.gettempdir()
         if tmp.isascii():
@@ -115,6 +119,18 @@ class PluginInitializer:
         self._provider_check_attempts = 0
         self._max_provider_attempts = 60
         self._retry_task: asyncio.Task | None = None
+        self._index_maintenance_task: asyncio.Task | None = None
+        self._graph_index_requires_rebuild = False
+        self._index_maintenance_status: dict[str, Any] = {
+            "state": "idle",
+            "reason": "",
+            "current": 0,
+            "total": 0,
+            "message": "",
+            "started_at": None,
+            "finished_at": None,
+            "result": None,
+        }
 
     async def initialize(self) -> bool:
         """
@@ -503,7 +519,9 @@ class PluginInitializer:
             # 检查索引文件维度与当前 embedding provider 维度是否一致
             await self._check_and_fix_dimension_mismatch(str(index_path))
             if graph_memory_enabled:
-                await self._check_and_fix_dimension_mismatch(str(graph_index_path))
+                self._graph_index_requires_rebuild = (
+                    await self._check_and_fix_dimension_mismatch(str(graph_index_path))
+                )
 
             self.db = faiss_vec_db_cls(
                 str(db_path),
@@ -787,9 +805,70 @@ class PluginInitializer:
             logger.error(f"数据库迁移检查失败: {e}", exc_info=True)
 
     async def _auto_rebuild_index_if_needed(self):
-        """自动检查并重建索引"""
+        """Schedule index checking without blocking core plugin readiness."""
+        if self._index_maintenance_task and not self._index_maintenance_task.done():
+            return
+        if not self.index_validator or not self.memory_engine:
+            return
+
+        self._set_index_maintenance_status(
+            state="checking",
+            reason="startup consistency check",
+            current=0,
+            total=0,
+            message="正在检查索引一致性",
+            started_at=time.time(),
+            finished_at=None,
+            result=None,
+        )
+        self._index_maintenance_task = asyncio.create_task(
+            self._run_index_maintenance()
+        )
+        self._index_maintenance_task.add_done_callback(self._on_index_maintenance_done)
+
+    def _set_index_maintenance_status(self, **updates: Any) -> None:
+        self._index_maintenance_status.update(updates)
+        if self.memory_engine is not None:
+            self.memory_engine.index_maintenance_status = dict(
+                self._index_maintenance_status
+            )
+
+    @property
+    def index_maintenance_status(self) -> dict[str, Any]:
+        return dict(self._index_maintenance_status)
+
+    def _on_index_maintenance_done(self, task: asyncio.Task) -> None:
+        if self._index_maintenance_task is task:
+            self._index_maintenance_task = None
+        if task.cancelled():
+            return
+        try:
+            exception = task.exception()
+        except Exception:
+            return
+        if exception:
+            logger.error(f"索引维护任务异常退出: {exception}", exc_info=exception)
+
+    async def _run_index_maintenance(self) -> None:
+        """Check and repair indexes while the plugin remains available."""
         try:
             if not self.index_validator or not self.memory_engine:
+                return
+
+            fingerprint_changed = False
+            check_fingerprint = getattr(
+                self.index_validator, "provider_fingerprint_changed", None
+            )
+            if callable(check_fingerprint):
+                fingerprint_changed = bool(await check_fingerprint())
+            if fingerprint_changed:
+                status = await self.index_validator.check_consistency()
+                await self._run_scheduled_index_rebuild(
+                    "Embedding Provider 指纹已变化",
+                    status.documents_count,
+                    force_full_vector=True,
+                    rebuild_graph=True,
+                )
                 return
 
             # 检查v1迁移状态
@@ -799,17 +878,8 @@ class PluginInitializer:
             ) = await self.index_validator.get_migration_status()
 
             if needs_migration_rebuild:
-                logger.info(f"检测到 v1 迁移数据需要重建索引（{pending_count} 条文档）")
-                logger.info("开始自动重建索引。")
-
-                result = await self.index_validator.rebuild_indexes(self.memory_engine)
-
-                if result["success"]:
-                    logger.info(
-                        f"索引自动重建完成: 成功 {result['processed']} 条, 失败 {result['errors']} 条"
-                    )
-                else:
-                    logger.error(f"索引自动重建失败: {result.get('message')}")
+                reason = f"v1 迁移数据需要重建索引（{pending_count} 条文档）"
+                await self._run_scheduled_index_rebuild(reason, pending_count)
                 return
 
             # 检查索引一致性
@@ -817,24 +887,142 @@ class PluginInitializer:
 
             if not status.is_consistent and status.needs_rebuild:
                 logger.warning(f"检测到索引不一致: {status.reason}")
-                logger.info(
-                    f"当前索引计数 - Documents: {status.documents_count}, BM25: {status.bm25_count}, Vector: {status.vector_count}"
+                await self._run_scheduled_index_rebuild(
+                    status.reason, status.documents_count
                 )
-                logger.info("开始自动重建索引。")
-
-                result = await self.index_validator.rebuild_indexes(self.memory_engine)
-
-                if result["success"]:
-                    logger.info(
-                        f"索引自动重建完成: 成功 {result['processed']} 条, 失败 {result['errors']} 条"
-                    )
-                else:
-                    logger.error(f"索引自动重建失败: {result.get('message')}")
             else:
                 logger.info(f"索引一致性检查通过: {status.reason}")
+                graph_result = None
+                if self._graph_index_requires_rebuild:
+                    graph_result = await self._run_graph_index_rebuild()
+                self._set_index_maintenance_status(
+                    state="ready",
+                    reason=status.reason,
+                    current=status.documents_count,
+                    total=status.documents_count,
+                    message=(
+                        "索引一致性检查通过，图谱索引已重建"
+                        if graph_result is not None
+                        else "索引一致性检查通过"
+                    ),
+                    finished_at=time.time(),
+                    result=(
+                        {"success": True, "graph_rebuild": graph_result}
+                        if graph_result is not None
+                        else None
+                    ),
+                )
 
+        except asyncio.CancelledError:
+            self._set_index_maintenance_status(
+                state="cancelled",
+                message="索引维护已取消",
+                finished_at=time.time(),
+            )
+            raise
         except Exception as e:
             logger.error(f"自动重建索引失败: {e}", exc_info=True)
+            self._set_index_maintenance_status(
+                state="failed",
+                message=str(e),
+                finished_at=time.time(),
+                result={"success": False, "error": str(e)},
+            )
+
+    async def _run_scheduled_index_rebuild(
+        self,
+        reason: str,
+        expected_total: int,
+        *,
+        force_full_vector: bool = False,
+        rebuild_graph: bool = False,
+    ) -> None:
+        if not self.index_validator or not self.memory_engine:
+            return
+
+        self._set_index_maintenance_status(
+            state="rebuilding",
+            reason=reason,
+            current=0,
+            total=max(0, int(expected_total)),
+            message="开始后台重建索引",
+        )
+        logger.info(f"开始后台索引维护: {reason}")
+
+        async def update_progress(current: int, total: int, message: str) -> None:
+            self._set_index_maintenance_status(
+                current=max(0, int(current)),
+                total=max(0, int(total)),
+                message=message,
+            )
+
+        rebuild_kwargs: dict[str, Any] = {"progress_callback": update_progress}
+        if force_full_vector:
+            rebuild_kwargs["force_full_vector"] = True
+        result = await self.index_validator.rebuild_indexes(
+            self.memory_engine, **rebuild_kwargs
+        )
+        success = bool(result.get("success"))
+        partial = bool(result.get("partial"))
+
+        check_consistency = getattr(self.index_validator, "check_consistency", None)
+        if success and callable(check_consistency):
+            final_status = await check_consistency()
+            if not final_status.is_consistent and final_status.needs_rebuild:
+                logger.info(
+                    "索引维护期间检测到并发写入，执行一次收尾补偿: "
+                    f"{final_status.reason}"
+                )
+                reconciliation = await self.index_validator.rebuild_indexes(
+                    self.memory_engine,
+                    progress_callback=update_progress,
+                )
+                result["reconciliation"] = dict(reconciliation)
+                success = bool(reconciliation.get("success"))
+                partial = partial or bool(reconciliation.get("partial"))
+                if success:
+                    final_status = await check_consistency()
+
+            if success and not final_status.is_consistent:
+                partial = True
+                result["post_check"] = {
+                    "consistent": False,
+                    "reason": final_status.reason,
+                }
+
+        if (
+            success
+            and not partial
+            and (rebuild_graph or self._graph_index_requires_rebuild)
+        ):
+            result["graph_rebuild"] = await self._run_graph_index_rebuild()
+
+        result["success"] = success
+        result["partial"] = partial
+        state = "partial" if success and partial else "ready" if success else "failed"
+        self._set_index_maintenance_status(
+            state=state,
+            current=int(result.get("processed", 0) or 0),
+            total=int(result.get("total", expected_total) or 0),
+            message=str(result.get("message") or "索引维护完成"),
+            finished_at=time.time(),
+            result=dict(result),
+        )
+        if success:
+            logger.info(
+                f"索引后台维护完成: 成功 {result.get('processed', 0)} 条, "
+                f"失败 {result.get('errors', 0)} 条"
+            )
+        else:
+            logger.error(f"索引后台维护失败: {result.get('message')}")
+
+    async def _run_graph_index_rebuild(self) -> dict[str, int]:
+        if self.memory_engine is None:
+            return {"rebuilt": 0, "skipped": 0}
+        self._set_index_maintenance_status(message="正在重建图谱索引")
+        result = await self.memory_engine.rebuild_graph_index()
+        self._graph_index_requires_rebuild = False
+        return result
 
     async def _repair_message_counts(self, conversation_store: ConversationStore):
         """修复会话表中 message_count 与实际消息数量不一致的问题"""
@@ -891,7 +1079,7 @@ class PluginInitializer:
 
         return self._initialization_complete
 
-    async def _check_and_fix_dimension_mismatch(self, index_path: str) -> None:
+    async def _check_and_fix_dimension_mismatch(self, index_path: str) -> bool:
         """
         检查 FAISS 索引维度与当前 embedding provider 维度是否一致
 
@@ -903,19 +1091,19 @@ class PluginInitializer:
             index_path: FAISS 索引文件路径
         """
         if not os.path.exists(index_path):
-            return
+            return False
 
         # 空文件不是有效索引，直接删除让 initialize() 重建，避免 faiss 抛异常
         try:
             if os.path.getsize(index_path) == 0:
                 os.remove(index_path)
                 logger.debug(f"已删除空索引文件: {_sanitize_path(index_path)}")
-                return
+                return True
         except OSError:
             pass
 
         try:
-            import faiss
+            import faiss  # noqa: F401
         except (ImportError, ModuleNotFoundError, SystemError, OSError) as exc:
             raise InitializationError(
                 "FAISS 初始化失败，无法读取索引文件。"
@@ -932,8 +1120,10 @@ class PluginInitializer:
             # 文件在 os.path.exists 和 faiss.read_index 之间消失（如被外部进程删除），
             # 这不是坏文件，不需要隔离，让 initialize() 自动重建即可
             if "No such file" in error_msg or "could not open" in error_msg:
-                logger.debug(f"FAISS 索引文件({_sanitize_path(index_path)})在检查时不可访问，将由 initialize() 重建: {e}")
-                return
+                logger.debug(
+                    f"FAISS 索引文件({_sanitize_path(index_path)})在检查时不可访问，将由 initialize() 重建: {e}"
+                )
+                return False
             # 真正的坏文件：直接删除（系统会自动重建），避免累积 .corrupt_* 文件
             try:
                 os.remove(index_path)
@@ -947,7 +1137,7 @@ class PluginInitializer:
                     f"检查索引维度时出错，且删除坏索引失败: {e}",
                     exc_info=True,
                 )
-            return
+            return True
 
         # 对比维度 — 放在坏索引处理之外，避免 embedding_provider 异常误删健康索引
         old_dim = old_index.d
@@ -959,13 +1149,15 @@ class PluginInitializer:
                 f"当前 Embedding Provider 维度={new_dim}"
             )
             logger.warning(
-                "这通常由 Embedding 模型切换导致。"
-                "旧索引将被删除，系统会自动重建索引。"
+                "这通常由 Embedding 模型切换导致。旧索引将被删除，系统会自动重建索引。"
             )
 
             os.remove(index_path)
             logger.info(f"已删除不兼容的旧索引文件: {_sanitize_path(index_path)}")
             logger.info("注意: 向量检索功能将暂时不可用，直到重新导入记忆数据。")
+            return True
+
+        return False
 
     @staticmethod
     def _faiss_read_index_safe(index_path: str):
@@ -975,11 +1167,13 @@ class PluginInitializer:
         """
         if not _needs_bridge(index_path):
             import faiss
+
             return faiss.read_index(index_path)
         tmp = _make_temp_file("_faiss_read")
         try:
             shutil.copy2(index_path, tmp)
             import faiss
+
             return faiss.read_index(tmp)
         finally:
             if os.path.exists(tmp):
@@ -996,6 +1190,14 @@ class PluginInitializer:
 
     async def stop_background_tasks(self) -> None:
         """停止初始化阶段的后台任务（如Provider重试）"""
+        if self._index_maintenance_task and not self._index_maintenance_task.done():
+            self._index_maintenance_task.cancel()
+            try:
+                await self._index_maintenance_task
+            except asyncio.CancelledError:
+                pass
+        self._index_maintenance_task = None
+
         if self._retry_task and not self._retry_task.done():
             self._retry_task.cancel()
             try:

--- a/core/validators/index_validator.py
+++ b/core/validators/index_validator.py
@@ -3,7 +3,10 @@
 """
 
 import asyncio
+import hashlib
+import json
 import os
+import time
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -43,6 +46,7 @@ class IndexValidator:
         """
         self.db_path = db_path
         self.faiss_db = faiss_db
+        self._maintenance_lock = asyncio.Lock()
 
     DEFAULT_REBUILD_BATCH_SIZE = 50
     DEFAULT_EMBEDDING_BATCH_SIZE = 8
@@ -53,6 +57,100 @@ class IndexValidator:
     DEFAULT_REQUEST_DELAY = 5.0
     RATE_LIMIT_RETRY_MIN_DELAY = 30.0
     DEFAULT_MAX_FAILURE_RATIO = 0.02
+    VECTOR_SCHEMA_VERSION = "document-vector-v2"
+    ACTIVE_DOCUMENT_SQL = (
+        "COALESCE(json_extract(metadata, '$.status'), 'active') = 'active'"
+    )
+
+    def get_provider_fingerprint(self) -> str:
+        provider = getattr(self.faiss_db, "embedding_provider", None)
+        provider_config = getattr(provider, "provider_config", {}) or {}
+        if not isinstance(provider_config, dict):
+            provider_config = {}
+
+        get_model = getattr(provider, "get_model", None)
+        try:
+            model = get_model() if callable(get_model) else None
+        except Exception:
+            model = None
+        model = (
+            model
+            or getattr(provider, "model", None)
+            or getattr(provider, "model_name", None)
+            or provider_config.get("embedding_model")
+            or provider_config.get("model")
+            or "unknown"
+        )
+
+        get_dim = getattr(provider, "get_dim", None)
+        try:
+            dimension = int(get_dim()) if callable(get_dim) else 0
+        except Exception:
+            dimension = 0
+        if dimension <= 0:
+            storage = getattr(self.faiss_db, "embedding_storage", None)
+            dimension = int(getattr(storage, "dimension", 0) or 0)
+
+        payload = {
+            "schema": self.VECTOR_SCHEMA_VERSION,
+            "provider_class": (
+                f"{type(provider).__module__}.{type(provider).__qualname__}"
+                if provider is not None
+                else "unknown"
+            ),
+            "provider_id": provider_config.get("id", "unknown"),
+            "provider_type": provider_config.get("type", "unknown"),
+            "model": str(model),
+            "dimension": dimension,
+            "dimensions_mode": provider_config.get("embedding_dimensions_mode"),
+            "input_type": provider_config.get("input_type"),
+        }
+        encoded = json.dumps(
+            payload, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    async def provider_fingerprint_changed(self) -> bool:
+        """Adopt legacy indexes once, then detect semantic provider changes."""
+        current = self.get_provider_fingerprint()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS migration_status (
+                    key TEXT PRIMARY KEY,
+                    value TEXT,
+                    updated_at TEXT
+                )
+                """
+            )
+            cursor = await db.execute(
+                "SELECT value FROM migration_status WHERE key = ?",
+                ("document_vector_provider_fingerprint",),
+            )
+            row = await cursor.fetchone()
+            if row is None:
+                await db.execute(
+                    """
+                    INSERT INTO migration_status(key, value, updated_at)
+                    VALUES (?, ?, datetime('now'))
+                    """,
+                    ("document_vector_provider_fingerprint", current),
+                )
+                await db.commit()
+                return False
+            return str(row[0] or "") != current
+
+    async def record_provider_fingerprint(self) -> None:
+        current = self.get_provider_fingerprint()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """
+                INSERT OR REPLACE INTO migration_status(key, value, updated_at)
+                VALUES (?, ?, datetime('now'))
+                """,
+                ("document_vector_provider_fingerprint", current),
+            )
+            await db.commit()
 
     async def _clear_bm25_with_retry(
         self, table_name: str = "livingmemory_memories_fts", max_attempts: int = 5
@@ -82,6 +180,53 @@ class IndexValidator:
                     continue
                 raise
 
+    async def _create_bm25_shadow(self, table_name: str) -> str:
+        """Create a fresh FTS5 table without touching the live index."""
+        shadow_table = f"{table_name}_rebuild"
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("PRAGMA busy_timeout = 10000")
+            await db.execute(f"DROP TABLE IF EXISTS {shadow_table}")
+            await db.execute(
+                f"""
+                CREATE VIRTUAL TABLE {shadow_table}
+                USING fts5(
+                    content,
+                    doc_id UNINDEXED,
+                    tokenize='unicode61'
+                )
+                """
+            )
+            await db.commit()
+        return shadow_table
+
+    async def _drop_bm25_shadow(self, shadow_table: str) -> None:
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("PRAGMA busy_timeout = 10000")
+            await db.execute(f"DROP TABLE IF EXISTS {shadow_table}")
+            await db.commit()
+
+    async def _switch_bm25_shadow(self, live_table: str, shadow_table: str) -> None:
+        """Atomically replace the live FTS table after a complete build."""
+        old_table = f"{live_table}_previous"
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("PRAGMA busy_timeout = 10000")
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                await db.execute(f"DROP TABLE IF EXISTS {old_table}")
+                await db.execute(f"ALTER TABLE {live_table} RENAME TO {old_table}")
+                await db.execute(f"ALTER TABLE {shadow_table} RENAME TO {live_table}")
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+
+        # Keep the switch transaction short. The previous generation can be
+        # dropped after readers have observed the new schema.
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("PRAGMA busy_timeout = 10000")
+            await db.execute(f"DROP TABLE IF EXISTS {old_table}")
+            await db.commit()
+
     async def check_consistency(self) -> IndexStatus:
         """
         检查索引一致性
@@ -92,11 +237,15 @@ class IndexValidator:
         try:
             async with aiosqlite.connect(self.db_path) as db:
                 # 1. 获取documents表中的文档数和ID集合
-                cursor = await db.execute("SELECT COUNT(*) FROM documents")
+                cursor = await db.execute(
+                    f"SELECT COUNT(*) FROM documents WHERE {self.ACTIVE_DOCUMENT_SQL}"
+                )
                 count_result = await cursor.fetchone()
                 documents_count = count_result[0] if count_result else 0
 
-                cursor = await db.execute("SELECT id FROM documents")
+                cursor = await db.execute(
+                    f"SELECT id FROM documents WHERE {self.ACTIVE_DOCUMENT_SQL}"
+                )
                 doc_ids = {row[0] for row in await cursor.fetchall()}
 
                 # 2. 检查BM25索引（livingmemory_memories_fts表）
@@ -328,13 +477,17 @@ class IndexValidator:
 
     async def _get_document_count(self) -> int:
         async with aiosqlite.connect(self.db_path) as db:
-            cursor = await db.execute("SELECT COUNT(*) FROM documents")
+            cursor = await db.execute(
+                f"SELECT COUNT(*) FROM documents WHERE {self.ACTIVE_DOCUMENT_SQL}"
+            )
             row = await cursor.fetchone()
             return int(row[0]) if row else 0
 
     async def _get_document_ids(self) -> set[int]:
         async with aiosqlite.connect(self.db_path) as db:
-            cursor = await db.execute("SELECT id FROM documents")
+            cursor = await db.execute(
+                f"SELECT id FROM documents WHERE {self.ACTIVE_DOCUMENT_SQL}"
+            )
             return {int(row[0]) for row in await cursor.fetchall()}
 
     async def _iter_document_batches(
@@ -354,6 +507,7 @@ class IndexValidator:
                         SELECT id, doc_id, text, metadata
                         FROM documents
                         WHERE id IN ({placeholders})
+                          AND {self.ACTIVE_DOCUMENT_SQL}
                         ORDER BY id
                         """,
                         chunk,
@@ -366,10 +520,11 @@ class IndexValidator:
             async with aiosqlite.connect(self.db_path) as db:
                 await db.execute("PRAGMA busy_timeout = 10000")
                 cursor = await db.execute(
-                    """
+                    f"""
                     SELECT id, doc_id, text, metadata
                     FROM documents
                     WHERE id > ?
+                      AND {self.ACTIVE_DOCUMENT_SQL}
                     ORDER BY id
                     LIMIT ?
                     """,
@@ -389,9 +544,8 @@ class IndexValidator:
             return 0
         return int(getattr(index, "ntotal", 0))
 
-    def _get_vector_ids(self) -> set[int] | None:
-        embedding_storage = getattr(self.faiss_db, "embedding_storage", None)
-        index = getattr(embedding_storage, "index", None)
+    @staticmethod
+    def _get_ids_from_index(index: Any) -> set[int] | None:
         if index is None:
             return set()
         try:
@@ -405,6 +559,11 @@ class IndexValidator:
         except Exception as e:
             logger.debug(f"读取向量ID失败: {e}")
         return None
+
+    def _get_vector_ids(self) -> set[int] | None:
+        embedding_storage = getattr(self.faiss_db, "embedding_storage", None)
+        index = getattr(embedding_storage, "index", None)
+        return self._get_ids_from_index(index)
 
     async def _rebuild_bm25_index(
         self,
@@ -424,69 +583,83 @@ class IndexValidator:
         batch_size = int(options["batch_size"])
         max_failure_ratio = float(options["max_failure_ratio"])
 
-        await self._clear_bm25_with_retry(table_name)
+        shadow_table = await self._create_bm25_shadow(table_name)
         processed = 0
         failed_ids: set[int] = set()
+        switched = False
 
-        async for batch in self._iter_document_batches(batch_size):
-            rows_to_insert: list[tuple[int, str]] = []
-            for doc_id, _doc_uuid, text, _metadata_json in batch:
-                try:
-                    if hasattr(text_processor, "preprocess_for_bm25"):
-                        processed_content = text_processor.preprocess_for_bm25(
-                            text or ""
-                        )
-                    else:
-                        tokens = text_processor.tokenize(text or "", True)
-                        processed_content = " ".join(tokens)
-                    rows_to_insert.append((int(doc_id), processed_content))
-                except Exception as e:
-                    failed_ids.add(int(doc_id))
-                    logger.error(f"BM25 预处理失败 doc_id={doc_id}: {e}")
+        try:
+            async for batch in self._iter_document_batches(batch_size):
+                rows_to_insert: list[tuple[int, str]] = []
+                for doc_id, _doc_uuid, text, _metadata_json in batch:
+                    try:
+                        if hasattr(text_processor, "preprocess_for_bm25"):
+                            processed_content = text_processor.preprocess_for_bm25(
+                                text or ""
+                            )
+                        else:
+                            tokens = text_processor.tokenize(text or "", True)
+                            processed_content = " ".join(tokens)
+                        rows_to_insert.append((int(doc_id), processed_content))
+                    except Exception as e:
+                        failed_ids.add(int(doc_id))
+                        logger.error(f"BM25 预处理失败 doc_id={doc_id}: {e}")
 
-            if rows_to_insert:
-                try:
-                    async with aiosqlite.connect(self.db_path) as db:
-                        await db.execute("PRAGMA busy_timeout = 10000")
-                        await db.executemany(
-                            f"INSERT INTO {table_name}(doc_id, content) VALUES (?, ?)",
-                            rows_to_insert,
+                if rows_to_insert:
+                    try:
+                        async with aiosqlite.connect(self.db_path) as db:
+                            await db.execute("PRAGMA busy_timeout = 10000")
+                            await db.executemany(
+                                f"INSERT INTO {shadow_table}(doc_id, content) VALUES (?, ?)",
+                                rows_to_insert,
+                            )
+                            await db.commit()
+                        processed += len(rows_to_insert)
+                    except Exception as batch_error:
+                        logger.warning(
+                            f"BM25 shadow 批量写入失败，将逐条重试: {batch_error}"
                         )
-                        await db.commit()
-                    processed += len(rows_to_insert)
-                except Exception as batch_error:
-                    logger.warning(f"BM25 批量写入失败，将逐条重试: {batch_error}")
-                    for row_doc_id, processed_content in rows_to_insert:
-                        try:
-                            async with aiosqlite.connect(self.db_path) as db:
-                                await db.execute("PRAGMA busy_timeout = 10000")
-                                await db.execute(
-                                    f"INSERT INTO {table_name}(doc_id, content) VALUES (?, ?)",
-                                    (row_doc_id, processed_content),
+                        for row_doc_id, processed_content in rows_to_insert:
+                            try:
+                                async with aiosqlite.connect(self.db_path) as db:
+                                    await db.execute("PRAGMA busy_timeout = 10000")
+                                    await db.execute(
+                                        f"INSERT INTO {shadow_table}(doc_id, content) VALUES (?, ?)",
+                                        (row_doc_id, processed_content),
+                                    )
+                                    await db.commit()
+                                processed += 1
+                            except Exception as e:
+                                failed_ids.add(int(row_doc_id))
+                                logger.error(
+                                    f"BM25 shadow 写入失败 doc_id={row_doc_id}: {e}"
                                 )
-                                await db.commit()
-                            processed += 1
-                        except Exception as e:
-                            failed_ids.add(int(row_doc_id))
-                            logger.error(f"BM25 写入失败 doc_id={row_doc_id}: {e}")
 
-            if progress_callback:
-                await progress_callback(
-                    processed,
-                    total,
-                    f"BM25 已处理 {processed}/{total} 条",
-                )
+                if progress_callback:
+                    await progress_callback(
+                        processed,
+                        total,
+                        f"BM25 已处理 {processed}/{total} 条",
+                    )
 
-            if self._failure_ratio(len(failed_ids), total) > max_failure_ratio:
-                logger.error(
-                    f"BM25 重建失败率过高: {len(failed_ids)}/{total}，停止后续重建"
-                )
-                break
+                if self._failure_ratio(len(failed_ids), total) > max_failure_ratio:
+                    logger.error(
+                        f"BM25 重建失败率过高: {len(failed_ids)}/{total}，停止后续重建"
+                    )
+                    break
+
+            if self._failure_ratio(len(failed_ids), total) <= max_failure_ratio:
+                await self._switch_bm25_shadow(table_name, shadow_table)
+                switched = True
+        finally:
+            if not switched:
+                await self._drop_bm25_shadow(shadow_table)
 
         return {
             "processed": processed,
             "errors": len(failed_ids),
             "failed_ids": failed_ids,
+            "switched": switched,
         }
 
     async def _embed_batch_with_retry(
@@ -502,23 +675,33 @@ class IndexValidator:
         retry_base_delay = float(options["retry_base_delay"])
         embedding_batch_size = int(options["embedding_batch_size"])
         request_delay = float(options["request_delay"])
+        tasks_limit = max(1, int(options.get("tasks_limit", 1)))
         vectors: list[Any] = []
+        chunks = [
+            contents[start : start + embedding_batch_size]
+            for start in range(0, len(contents), embedding_batch_size)
+        ]
 
-        for start in range(0, len(contents), embedding_batch_size):
-            chunk = contents[start : start + embedding_batch_size]
+        for wave_start in range(0, len(chunks), tasks_limit):
+            wave = chunks[wave_start : wave_start + tasks_limit]
             logger.debug(
-                "Embedding 子请求: "
-                f"offset={start}, size={len(chunk)}, total={len(contents)}"
+                "Embedding 并发窗口: "
+                f"offset={wave_start}, requests={len(wave)}, total_requests={len(chunks)}"
             )
-            vectors.extend(
-                await self._embed_request_with_retry(
-                    provider,
-                    chunk,
-                    max_retries=max_retries,
-                    retry_base_delay=retry_base_delay,
+            wave_results = await asyncio.gather(
+                *(
+                    self._embed_request_with_retry(
+                        provider,
+                        chunk,
+                        max_retries=max_retries,
+                        retry_base_delay=retry_base_delay,
+                    )
+                    for chunk in wave
                 )
             )
-            if request_delay > 0 and start + embedding_batch_size < len(contents):
+            for result in wave_results:
+                vectors.extend(result)
+            if request_delay > 0 and wave_start + tasks_limit < len(chunks):
                 await asyncio.sleep(request_delay)
 
         return vectors
@@ -666,69 +849,134 @@ class IndexValidator:
         if dimension <= 0:
             raise RuntimeError("无法重建向量索引：索引维度无效")
 
-        temp_index = faiss.IndexIDMap(faiss.IndexFlatL2(dimension))
-        processed = 0
+        index_path = getattr(embedding_storage, "path", None)
+        temp_path = f"{index_path}.rebuild.tmp" if index_path else None
+        metadata_path = f"{temp_path}.json" if temp_path else None
+        provider_fingerprint = self.get_provider_fingerprint()
+        active_document_ids = await self._get_document_ids()
+
+        temp_index = None
+        if temp_path and metadata_path and os.path.exists(temp_path):
+            try:
+                with open(metadata_path, encoding="utf-8") as metadata_file:
+                    checkpoint_metadata = json.load(metadata_file)
+                if (
+                    checkpoint_metadata.get("provider_fingerprint")
+                    == provider_fingerprint
+                    and int(checkpoint_metadata.get("dimension", 0)) == dimension
+                ):
+                    candidate = await asyncio.to_thread(faiss.read_index, temp_path)
+                    if int(getattr(candidate, "d", 0)) == dimension:
+                        temp_index = candidate
+                        logger.info(f"恢复向量重建检查点: vectors={candidate.ntotal}")
+            except Exception as e:
+                logger.warning(f"忽略无法恢复的向量重建检查点: {e}")
+
+        if temp_index is None:
+            temp_index = faiss.IndexIDMap(faiss.IndexFlatL2(dimension))
+            for stale_path in (temp_path, metadata_path):
+                if stale_path and os.path.exists(stale_path):
+                    try:
+                        os.remove(stale_path)
+                    except OSError:
+                        pass
+
+        checkpoint_ids = self._get_ids_from_index(temp_index) or set()
+        checkpoint_ids &= active_document_ids
+        remaining_ids = active_document_ids - checkpoint_ids
+        processed = len(checkpoint_ids)
         failed_ids: set[int] = set()
         batch_delay = float(options["batch_delay"])
         max_failure_ratio = float(options["max_failure_ratio"])
         batch_index = 0
 
-        async for batch in self._iter_document_batches(int(options["batch_size"])):
-            batch_index += 1
-            ids = [int(row[0]) for row in batch]
-            contents = [row[2] or "" for row in batch]
-            logger.info(
-                "向量重建批次开始: "
-                f"batch={batch_index}, size={len(ids)}, "
-                f"id_range={ids[0]}-{ids[-1]}, processed={processed}/{total}, "
-                f"failed={len(failed_ids)}"
-            )
-            try:
-                vectors = await self._embed_batch_with_retry(
-                    provider, contents, options
+        async def persist_checkpoint() -> None:
+            if not temp_path or not metadata_path:
+                return
+            writing_path = f"{temp_path}.writing"
+            await asyncio.to_thread(faiss.write_index, temp_index, writing_path)
+            os.replace(writing_path, temp_path)
+            checkpoint_metadata = {
+                "provider_fingerprint": provider_fingerprint,
+                "dimension": dimension,
+                "processed": int(temp_index.ntotal),
+                "updated_at": time.time(),
+            }
+            metadata_writing_path = f"{metadata_path}.writing"
+            with open(metadata_writing_path, "w", encoding="utf-8") as metadata_file:
+                json.dump(checkpoint_metadata, metadata_file, ensure_ascii=True)
+            os.replace(metadata_writing_path, metadata_path)
+
+        try:
+            async for batch in self._iter_document_batches(
+                int(options["batch_size"]), remaining_ids
+            ):
+                batch_index += 1
+                ids = [int(row[0]) for row in batch]
+                contents = [row[2] or "" for row in batch]
+                logger.info(
+                    "向量重建批次开始: "
+                    f"batch={batch_index}, size={len(ids)}, "
+                    f"id_range={ids[0]}-{ids[-1]}, processed={processed}/{total}, "
+                    f"failed={len(failed_ids)}"
                 )
-                vectors_array = np.asarray(vectors, dtype=np.float32)
-                if vectors_array.ndim != 2 or len(vectors_array) != len(ids):
-                    raise ValueError(
-                        f"Embedding 返回数量不匹配: 期望 {len(ids)}，实际 {len(vectors_array)}"
+                try:
+                    vectors = await self._embed_batch_with_retry(
+                        provider, contents, options
                     )
-                if vectors_array.shape[1] != dimension:
-                    raise ValueError(
-                        f"Embedding 维度不匹配: 期望 {dimension}，实际 {vectors_array.shape[1]}"
+                    vectors_array = np.asarray(vectors, dtype=np.float32)
+                    if vectors_array.ndim != 2 or len(vectors_array) != len(ids):
+                        raise ValueError(
+                            f"Embedding 返回数量不匹配: 期望 {len(ids)}，实际 {len(vectors_array)}"
+                        )
+                    if vectors_array.shape[1] != dimension:
+                        raise ValueError(
+                            f"Embedding 维度不匹配: 期望 {dimension}，实际 {vectors_array.shape[1]}"
+                        )
+                    temp_index.add_with_ids(
+                        vectors_array, np.asarray(ids, dtype=np.int64)
                     )
-                temp_index.add_with_ids(vectors_array, np.asarray(ids, dtype=np.int64))
-                processed += len(ids)
-            except Exception as e:
-                failed_ids.update(ids)
-                logger.error(f"向量重建批次失败 ids={ids[:3]}...: {e}", exc_info=True)
+                    processed += len(ids)
+                except Exception as e:
+                    failed_ids.update(ids)
+                    logger.error(
+                        f"向量重建批次失败 ids={ids[:3]}...: {e}", exc_info=True
+                    )
 
-            if progress_callback:
-                await progress_callback(
-                    processed,
-                    total,
-                    f"向量索引已处理 {processed}/{total} 条",
+                if progress_callback:
+                    await progress_callback(
+                        processed,
+                        total,
+                        f"向量索引已处理 {processed}/{total} 条",
+                    )
+
+                logger.info(
+                    "向量重建进度: "
+                    f"processed={processed}/{total}, failed={len(failed_ids)}, "
+                    f"failure_ratio={self._failure_ratio(len(failed_ids), total):.2%}"
                 )
 
-            logger.info(
-                "向量重建进度: "
-                f"processed={processed}/{total}, failed={len(failed_ids)}, "
-                f"failure_ratio={self._failure_ratio(len(failed_ids), total):.2%}"
-            )
+                if batch_index % 10 == 0:
+                    await persist_checkpoint()
 
-            if self._failure_ratio(len(failed_ids), total) > max_failure_ratio:
-                logger.error(
-                    f"向量重建失败率过高: {len(failed_ids)}/{total}，不会切换新索引"
-                )
-                return {
-                    "mode": "full",
-                    "processed": processed,
-                    "errors": len(failed_ids),
-                    "failed_ids": failed_ids,
-                    "switched": False,
-                    "partial": True,
-                }
-            if batch_delay > 0:
-                await asyncio.sleep(batch_delay)
+                if self._failure_ratio(len(failed_ids), total) > max_failure_ratio:
+                    logger.error(
+                        f"向量重建失败率过高: {len(failed_ids)}/{total}，不会切换新索引"
+                    )
+                    await persist_checkpoint()
+                    return {
+                        "mode": "full",
+                        "processed": processed,
+                        "errors": len(failed_ids),
+                        "failed_ids": failed_ids,
+                        "switched": False,
+                        "partial": True,
+                    }
+                if batch_delay > 0:
+                    await asyncio.sleep(batch_delay)
+        except asyncio.CancelledError:
+            await asyncio.shield(persist_checkpoint())
+            raise
 
         if total > 0 and processed == 0:
             return {
@@ -740,18 +988,12 @@ class IndexValidator:
                 "partial": True,
             }
 
-        index_path = getattr(embedding_storage, "path", None)
         if index_path:
-            temp_path = f"{index_path}.rebuild.tmp"
-            try:
-                faiss.write_index(temp_index, temp_path)
+            await persist_checkpoint()
+            if temp_path:
                 os.replace(temp_path, index_path)
-            finally:
-                if os.path.exists(temp_path):
-                    try:
-                        os.remove(temp_path)
-                    except OSError:
-                        pass
+            if metadata_path and os.path.exists(metadata_path):
+                os.remove(metadata_path)
 
         embedding_storage.index = temp_index
         return {
@@ -769,7 +1011,14 @@ class IndexValidator:
         total: int,
         options: dict[str, Any],
         progress_callback=None,
+        force_full: bool = False,
     ) -> dict[str, Any]:
+        if force_full:
+            logger.info("Embedding Provider 指纹已变化，执行安全全量向量重建")
+            return await self._rebuild_vector_index_full(
+                memory_engine, total, options, progress_callback
+            )
+
         document_ids = await self._get_document_ids()
         if not document_ids:
             return {
@@ -857,7 +1106,11 @@ class IndexValidator:
             logger.warning(f"更新迁移状态失败: {e}")
 
     async def rebuild_indexes(
-        self, memory_engine: Any, progress_callback=None
+        self,
+        memory_engine: Any,
+        progress_callback=None,
+        *,
+        force_full_vector: bool = False,
     ) -> dict[str, Any]:
         """
         分批安全重建索引
@@ -875,6 +1128,20 @@ class IndexValidator:
         Returns:
             Dict: 重建结果
         """
+        async with self._maintenance_lock:
+            return await self._rebuild_indexes_locked(
+                memory_engine,
+                progress_callback=progress_callback,
+                force_full_vector=force_full_vector,
+            )
+
+    async def _rebuild_indexes_locked(
+        self,
+        memory_engine: Any,
+        progress_callback=None,
+        *,
+        force_full_vector: bool = False,
+    ) -> dict[str, Any]:
         try:
             logger.info("开始分批安全重建索引。")
             options = self._get_rebuild_options(memory_engine)
@@ -929,7 +1196,11 @@ class IndexValidator:
                 }
 
             vector_result = await self._rebuild_or_repair_vector_index(
-                memory_engine, total, options, progress_callback
+                memory_engine,
+                total,
+                options,
+                progress_callback,
+                force_full=force_full_vector,
             )
             vector_failed_ids = set(vector_result["failed_ids"])
             failed_ids = bm25_failed_ids | vector_failed_ids
@@ -941,6 +1212,8 @@ class IndexValidator:
                 await self._update_migration_rebuild_status(
                     "partial" if partial else "true"
                 )
+                if not partial:
+                    await self.record_provider_fingerprint()
                 message = (
                     "索引重建完成"
                     if not partial

--- a/storage/graph_store.py
+++ b/storage/graph_store.py
@@ -529,6 +529,147 @@ class GraphStore:
             await db.commit()
         return vector_doc_ids
 
+    async def list_vector_doc_ids(self) -> list[int]:
+        async with self._connect() as db:
+            cursor = await db.execute(
+                "SELECT DISTINCT vector_doc_id FROM graph_entries "
+                "WHERE vector_doc_id IS NOT NULL"
+            )
+            return [int(row[0]) for row in await cursor.fetchall()]
+
+    async def list_vector_doc_ids_by_source(self) -> dict[int, list[int]]:
+        async with self._connect() as db:
+            cursor = await db.execute(
+                """
+                SELECT source_memory_id, vector_doc_id
+                FROM graph_entries
+                WHERE vector_doc_id IS NOT NULL
+                GROUP BY source_memory_id, vector_doc_id
+                """
+            )
+            result: dict[int, list[int]] = {}
+            for source_memory_id, vector_doc_id in await cursor.fetchall():
+                result.setdefault(int(source_memory_id), []).append(int(vector_doc_id))
+            return result
+
+    async def iter_memory_entry_groups(self, batch_size: int = 100):
+        """Yield graph-vector payloads grouped by source memory."""
+        last_memory_id = -1
+        while True:
+            async with self._connect() as db:
+                cursor = await db.execute(
+                    """
+                    SELECT DISTINCT source_memory_id
+                    FROM graph_entries
+                    WHERE source_memory_id > ?
+                    ORDER BY source_memory_id
+                    LIMIT ?
+                    """,
+                    (last_memory_id, max(1, int(batch_size))),
+                )
+                memory_ids = [int(row[0]) for row in await cursor.fetchall()]
+                if not memory_ids:
+                    break
+
+                placeholders = ",".join("?" for _ in memory_ids)
+                entry_cursor = await db.execute(
+                    f"""
+                    SELECT id, source_memory_id, content, metadata
+                    FROM graph_entries
+                    WHERE source_memory_id IN ({placeholders})
+                    ORDER BY source_memory_id, id
+                    """,
+                    memory_ids,
+                )
+                rows = await entry_cursor.fetchall()
+
+            grouped: dict[int, list[tuple[int, str, dict[str, Any]]]] = {}
+            for entry_id, source_memory_id, content, metadata in rows:
+                grouped.setdefault(int(source_memory_id), []).append(
+                    (int(entry_id), str(content or ""), self._from_json(metadata))
+                )
+            yield [
+                (
+                    source_memory_id,
+                    entries[0][0],
+                    [(content, metadata) for _, content, metadata in entries],
+                )
+                for source_memory_id, entries in grouped.items()
+                if entries
+            ]
+            last_memory_id = memory_ids[-1]
+
+    async def replace_all_from(self, shadow_db_path: str) -> None:
+        """Atomically replace live graph tables from a fully built shadow DB."""
+        async with self._connect() as db:
+            await db.execute("PRAGMA foreign_keys = OFF")
+            await db.execute("ATTACH DATABASE ? AS shadow_graph", (shadow_db_path,))
+            try:
+                await db.execute("BEGIN IMMEDIATE")
+                await db.execute("DELETE FROM livingmemory_graph_entries_fts")
+                await db.execute("DELETE FROM graph_entry_nodes")
+                await db.execute("DELETE FROM graph_entries")
+                await db.execute("DELETE FROM graph_edges")
+                await db.execute("DELETE FROM graph_nodes")
+
+                await db.execute(
+                    """
+                    INSERT INTO graph_nodes(
+                        id, node_key, node_type, node_value, canonical_value,
+                        metadata, created_at, updated_at
+                    )
+                    SELECT id, node_key, node_type, node_value, canonical_value,
+                           metadata, created_at, updated_at
+                    FROM shadow_graph.graph_nodes
+                    """
+                )
+                await db.execute(
+                    """
+                    INSERT INTO graph_edges(
+                        id, edge_key, source_node_id, target_node_id,
+                        relation_type, source_memory_id, weight, confidence,
+                        status, metadata, created_at, updated_at
+                    )
+                    SELECT id, edge_key, source_node_id, target_node_id,
+                           relation_type, source_memory_id, weight, confidence,
+                           status, metadata, created_at, updated_at
+                    FROM shadow_graph.graph_edges
+                    """
+                )
+                await db.execute(
+                    """
+                    INSERT INTO graph_entries(
+                        id, entry_key, source_memory_id, session_id, persona_id,
+                        entry_type, relation_type, content, metadata, edge_id,
+                        vector_doc_id, created_at, updated_at
+                    )
+                    SELECT id, entry_key, source_memory_id, session_id, persona_id,
+                           entry_type, relation_type, content, metadata, edge_id,
+                           vector_doc_id, created_at, updated_at
+                    FROM shadow_graph.graph_entries
+                    """
+                )
+                await db.execute(
+                    """
+                    INSERT INTO graph_entry_nodes(entry_id, node_id)
+                    SELECT entry_id, node_id
+                    FROM shadow_graph.graph_entry_nodes
+                    """
+                )
+                await db.execute(
+                    """
+                    INSERT INTO livingmemory_graph_entries_fts(content, entry_id)
+                    SELECT content, entry_id
+                    FROM shadow_graph.livingmemory_graph_entries_fts
+                    """
+                )
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+            finally:
+                await db.execute("DETACH DATABASE shadow_graph")
+
     async def delete_memory(self, source_memory_id: int) -> list[int]:
         """Delete graph artifacts belonging to one source memory."""
         vector_doc_ids: list[int] = []
@@ -721,7 +862,9 @@ class GraphStore:
         rows_by_id: dict[int, aiosqlite.Row] = {}
         async with self._connect() as db:
             db.row_factory = aiosqlite.Row
-            for start in range(0, len(normalized_tokens), self._NODE_TOKEN_QUERY_BATCH_SIZE):
+            for start in range(
+                0, len(normalized_tokens), self._NODE_TOKEN_QUERY_BATCH_SIZE
+            ):
                 batch = normalized_tokens[
                     start : start + self._NODE_TOKEN_QUERY_BATCH_SIZE
                 ]
@@ -1337,9 +1480,9 @@ class GraphStore:
         memories: list[dict[str, Any]] = []
         for row in memory_rows:
             metadata = self._from_json(row["metadata"])
-            summary = str(
-                metadata.get("canonical_summary") or row["content"] or ""
-            )[:500]
+            summary = str(metadata.get("canonical_summary") or row["content"] or "")[
+                :500
+            ]
             memories.append(
                 {
                     "memory_id": int(row["source_memory_id"]),

--- a/tests/integration/test_real_db_end_to_end.py
+++ b/tests/integration/test_real_db_end_to_end.py
@@ -209,7 +209,7 @@ async def test_graph_memory_batches_real_faiss_index_writes(
 
 
 @pytest.mark.asyncio
-async def test_graph_memory_full_rebuild_saves_real_faiss_twice(
+async def test_graph_memory_full_rebuild_saves_real_faiss_once(
     tmp_path: Path, monkeypatch
 ):
     graph_store = GraphStore(str(tmp_path / "graph_rebuild.db"))
@@ -267,7 +267,7 @@ async def test_graph_memory_full_rebuild_saves_real_faiss_twice(
         assert result == {"rebuilt": 10, "skipped": 0}
         assert stats["graph_entries"] > result["rebuilt"]
         assert vector_db.embedding_storage.index.ntotal == result["rebuilt"]
-        assert len(write_paths) == 2
+        assert len(write_paths) == 1
     finally:
         await vector_db.close()
 

--- a/tests/test_graph_memory.py
+++ b/tests/test_graph_memory.py
@@ -1,5 +1,7 @@
 """Tests for graph-memory indexing and dual-route retrieval."""
 
+import asyncio
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -269,6 +271,90 @@ async def test_graph_memory_manager_indexes_nodes_edges_and_entries(tmp_path: Pa
     vector_doc = next(iter(vector_db.docs.values()))
     assert vector_doc["metadata"]["graph_vector_granularity"] == "memory"
     assert vector_doc["metadata"]["graph_entry_count"] == stats["graph_entries"]
+
+
+@pytest.mark.asyncio
+async def test_graph_rebuild_failure_preserves_live_generation(
+    tmp_path: Path, monkeypatch
+):
+    graph_store = GraphStore(str(tmp_path / "graph_rebuild_failure.db"))
+    await graph_store.initialize()
+    vector_db = _FakeFaissDB()
+    manager = GraphMemoryManager(
+        graph_store=graph_store,
+        graph_vector_retriever=GraphVectorRetriever(vector_db),
+        graph_extractor=GraphExtractor(),
+    )
+    metadata = {
+        "canonical_summary": "live generation",
+        "topics": ["stable"],
+        "participants": ["Alice"],
+        "key_facts": ["old graph remains available"],
+    }
+    await manager.index_memory(1, "live generation", metadata)
+    live_snapshot = await graph_store.get_subgraph_for_memories([1])
+    live_vector_ids = set(vector_db.docs)
+
+    monkeypatch.setattr(
+        manager.graph_vector_retriever,
+        "add_memory_entries_batch",
+        AsyncMock(side_effect=RuntimeError("embedding failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="embedding failed"):
+        await manager.rebuild_memories(
+            [(2, "shadow generation", {**metadata, "topics": ["new"]})]
+        )
+
+    assert await graph_store.get_subgraph_for_memories([1]) == live_snapshot
+    assert set(vector_db.docs) == live_vector_ids
+
+
+@pytest.mark.asyncio
+async def test_graph_rebuild_replays_concurrent_changes(tmp_path: Path):
+    graph_store = GraphStore(str(tmp_path / "graph_rebuild_delta.db"))
+    await graph_store.initialize()
+    vector_db = _FakeFaissDB()
+    manager = GraphMemoryManager(
+        graph_store=graph_store,
+        graph_vector_retriever=GraphVectorRetriever(vector_db),
+        graph_extractor=GraphExtractor(),
+    )
+    metadata = {
+        "canonical_summary": "initial memory",
+        "topics": ["initial"],
+        "participants": ["Alice"],
+        "key_facts": ["initial fact"],
+    }
+    await manager.index_memory(1, "initial memory", metadata)
+
+    rebuild_started = asyncio.Event()
+    finish_rebuild = asyncio.Event()
+
+    async def batches():
+        yield [(1, "initial memory", metadata)]
+        rebuild_started.set()
+        await finish_rebuild.wait()
+
+    rebuild_task = asyncio.create_task(manager.rebuild_memory_batches(batches()))
+    await rebuild_started.wait()
+    await manager.delete_memory(1)
+    await manager.index_memory(
+        2,
+        "concurrent memory",
+        {
+            **metadata,
+            "canonical_summary": "concurrent memory",
+            "topics": ["concurrent"],
+        },
+    )
+    finish_rebuild.set()
+    await rebuild_task
+
+    assert not (await graph_store.get_subgraph_for_memories([1]))["memories"]
+    snapshot = await graph_store.get_subgraph_for_memories([2])
+    assert {item["memory_id"] for item in snapshot["memories"]} == {2}
+    assert len(vector_db.docs) == 1
 
 
 @pytest.mark.asyncio
@@ -586,6 +672,43 @@ async def test_memory_engine_rebuild_graph_index(tmp_path: Path):
     )
     assert memory_id > 0
 
+    # The lightweight FAISS fake does not persist its document row in SQLite.
+    # Graph rebuild deliberately streams from SQLite as the source of truth.
+    source_doc = engine.faiss_db.docs[memory_id]
+    await engine.db_connection.execute(
+        """
+        INSERT OR REPLACE INTO documents(id, doc_id, text, metadata)
+        VALUES (?, ?, ?, ?)
+        """,
+        (
+            memory_id,
+            source_doc["doc_id"],
+            source_doc["text"],
+            json.dumps(source_doc["metadata"], ensure_ascii=False),
+        ),
+    )
+    archived_id = memory_id + 100
+    await engine.db_connection.execute(
+        """
+        INSERT INTO documents(id, doc_id, text, metadata)
+        VALUES (?, ?, ?, ?)
+        """,
+        (
+            archived_id,
+            f"archived-{archived_id}",
+            "不应进入图谱重建",
+            json.dumps(
+                {
+                    **source_doc["metadata"],
+                    "status": "archived",
+                    "canonical_summary": "不应进入图谱重建",
+                },
+                ensure_ascii=False,
+            ),
+        ),
+    )
+    await engine.db_connection.commit()
+
     assert engine.graph_memory_manager is not None
     await engine.graph_memory_manager.delete_memory(memory_id)
 
@@ -593,13 +716,62 @@ async def test_memory_engine_rebuild_graph_index(tmp_path: Path):
     graph_vector_db.delete_documents_calls = 0
 
     rebuild_result = await engine.rebuild_graph_index()
-    assert rebuild_result["rebuilt"] >= 1
-    assert graph_vector_db.delete_documents_calls == 1
+    assert rebuild_result == {"rebuilt": 1, "skipped": 0}
+    assert graph_vector_db.delete_documents_calls == 0
     assert graph_vector_db.insert_batch_calls == 1
     assert len(graph_vector_db.docs) == rebuild_result["rebuilt"]
 
     stats = await engine.get_statistics()
     assert stats.get("graph_entries", 0) >= 1
+    archived_graph = await engine.graph_store.get_subgraph_for_memories([archived_id])
+    assert not archived_graph["memories"]
+    await engine.close()
+
+
+@pytest.mark.asyncio
+async def test_memory_engine_streams_active_graph_rebuild_batches(tmp_path: Path):
+    engine = MemoryEngine(
+        db_path=str(tmp_path / "memory_stream_rebuild.db"),
+        faiss_db=_FakeFaissDB(),
+        graph_vector_db=_FakeFaissDB(),
+        config={"fallback_enabled": True, "graph_memory_enabled": True},
+    )
+    await engine.initialize()
+    rows = []
+    for memory_id in range(1, 406):
+        status = "archived" if memory_id > 400 else "active"
+        rows.append(
+            (
+                memory_id,
+                f"doc-{memory_id}",
+                f"memory {memory_id}",
+                json.dumps({"status": status}),
+            )
+        )
+    await engine.db_connection.executemany(
+        "INSERT INTO documents(id, doc_id, text, metadata) VALUES (?, ?, ?, ?)",
+        rows,
+    )
+    await engine.db_connection.commit()
+
+    class RecordingGraphManager:
+        def __init__(self):
+            self.batch_sizes = []
+            self.memory_ids = []
+
+        async def rebuild_memory_batches(self, batches):
+            async for batch in batches:
+                self.batch_sizes.append(len(batch))
+                self.memory_ids.extend(memory_id for memory_id, _, _ in batch)
+            return {"rebuilt": len(self.memory_ids), "skipped": 0}
+
+    recorder = RecordingGraphManager()
+    engine.graph_memory_manager = recorder
+    result = await engine.rebuild_graph_index()
+
+    assert result == {"rebuilt": 400, "skipped": 0}
+    assert recorder.batch_sizes == [200, 200]
+    assert recorder.memory_ids == list(range(1, 401))
     await engine.close()
 
 

--- a/tests/test_index_validator.py
+++ b/tests/test_index_validator.py
@@ -2,6 +2,7 @@
 IndexValidator 测试。
 """
 
+import asyncio
 import importlib.util
 import json
 import sqlite3
@@ -56,7 +57,10 @@ class _DummyEmbeddingProvider:
         self.calls.append(list(contents))
         if any(content in self.fail_contents for content in contents):
             raise RuntimeError("模拟 embedding 批次失败")
-        return [[float(len(content)), float(index + 1)] for index, content in enumerate(contents)]
+        return [
+            [float(len(content)), float(index + 1)]
+            for index, content in enumerate(contents)
+        ]
 
 
 class _DummyEmbeddingStorage:
@@ -173,6 +177,14 @@ def _count_rows(db_path: Path, table_name: str) -> int:
 def _document_doc_ids(db_path: Path) -> list[str]:
     with sqlite3.connect(db_path) as conn:
         rows = conn.execute("SELECT doc_id FROM documents ORDER BY id").fetchall()
+        return [str(row[0]) for row in rows]
+
+
+def _fts_contents(db_path: Path, table_name: str) -> list[str]:
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            f"SELECT content FROM {table_name} ORDER BY doc_id"
+        ).fetchall()
         return [str(row[0]) for row in rows]
 
 
@@ -338,3 +350,193 @@ async def test_rebuild_indexes_repairs_only_missing_vectors_when_index_is_readab
     assert provider.calls == [["doc-4"]]
     assert memory_engine.faiss_db.embedding_storage.index.ntotal == 5
     assert _count_rows(db_path, "documents") == 5
+
+
+@pytest.mark.asyncio
+async def test_archived_documents_are_not_expected_or_rebuilt(tmp_path: Path):
+    db_path = tmp_path / "memory.db"
+    index_path = tmp_path / "memory.index"
+    _prepare_db(db_path, count=3)
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT metadata FROM documents WHERE id = 3").fetchone()
+        assert row is not None
+        metadata = json.loads(row[0])
+        metadata["status"] = "archived"
+        conn.execute(
+            "UPDATE documents SET metadata = ? WHERE id = 3",
+            (json.dumps(metadata, ensure_ascii=False),),
+        )
+        conn.execute("DELETE FROM livingmemory_memories_fts WHERE doc_id = 3")
+        conn.commit()
+
+    provider = _DummyEmbeddingProvider()
+    memory_engine = _DummyMemoryEngine(db_path, index_path, provider, batch_size=2)
+    _write_vectors(memory_engine.faiss_db.embedding_storage, [1, 2])
+    validator = IndexValidator(str(db_path), faiss_db=memory_engine.faiss_db)
+
+    status = await validator.check_consistency()
+    result = await validator.rebuild_indexes(memory_engine=memory_engine)
+
+    assert status.is_consistent is True
+    assert status.documents_count == 2
+    assert status.missing_in_bm25 == 0
+    assert status.missing_in_vector == 0
+    assert result["success"] is True
+    assert result["total"] == 2
+    assert provider.calls == []
+    assert _count_rows(db_path, "livingmemory_memories_fts") == 2
+    assert memory_engine.faiss_db.embedding_storage.index.ntotal == 2
+
+
+@pytest.mark.asyncio
+async def test_bm25_rebuild_failure_keeps_live_generation(tmp_path: Path):
+    db_path = tmp_path / "memory.db"
+    index_path = tmp_path / "memory.index"
+    _prepare_db(db_path, count=3)
+
+    class _FailingTextProcessor:
+        def preprocess_for_bm25(self, text: str) -> str:
+            raise RuntimeError(f"cannot tokenize {text}")
+
+    provider = _DummyEmbeddingProvider()
+    memory_engine = _DummyMemoryEngine(
+        db_path,
+        index_path,
+        provider,
+        batch_size=1,
+        failure_ratio=0.0,
+    )
+    memory_engine.bm25_retriever.text_processor = _FailingTextProcessor()
+    validator = IndexValidator(str(db_path), faiss_db=memory_engine.faiss_db)
+
+    result = await validator.rebuild_indexes(memory_engine=memory_engine)
+
+    assert result["success"] is False
+    assert _fts_contents(db_path, "livingmemory_memories_fts") == [
+        "old-doc-0",
+        "old-doc-1",
+        "old-doc-2",
+    ]
+    with sqlite3.connect(db_path) as conn:
+        shadow = conn.execute(
+            "SELECT name FROM sqlite_master WHERE name = ?",
+            ("livingmemory_memories_fts_rebuild",),
+        ).fetchone()
+    assert shadow is None
+
+
+@pytest.mark.asyncio
+async def test_provider_fingerprint_detects_same_dimension_model_change(tmp_path: Path):
+    db_path = tmp_path / "memory.db"
+    index_path = tmp_path / "memory.index"
+    _prepare_db(db_path, count=1)
+    provider = _DummyEmbeddingProvider()
+    provider.provider_config = {
+        "id": "embedding-main",
+        "type": "openai_embedding",
+        "embedding_model": "model-a",
+        "embedding_api_key": "must-not-be-persisted",
+    }
+    provider.model = "model-a"
+    memory_engine = _DummyMemoryEngine(db_path, index_path, provider)
+    validator = IndexValidator(str(db_path), faiss_db=memory_engine.faiss_db)
+
+    assert await validator.provider_fingerprint_changed() is False
+    provider.model = "model-b"
+    provider.provider_config["embedding_model"] = "model-b"
+    assert await validator.provider_fingerprint_changed() is True
+
+    await validator.record_provider_fingerprint()
+
+    assert await validator.provider_fingerprint_changed() is False
+    with sqlite3.connect(db_path) as conn:
+        stored = conn.execute(
+            "SELECT value FROM migration_status WHERE key = ?",
+            ("document_vector_provider_fingerprint",),
+        ).fetchone()
+    assert stored is not None
+    assert len(stored[0]) == 64
+    assert "must-not-be-persisted" not in stored[0]
+
+
+@pytest.mark.asyncio
+async def test_provider_change_forces_full_vector_generation(tmp_path: Path):
+    db_path = tmp_path / "memory.db"
+    index_path = tmp_path / "memory.index"
+    _prepare_db(db_path, count=2)
+    provider = _DummyEmbeddingProvider()
+    memory_engine = _DummyMemoryEngine(db_path, index_path, provider, batch_size=2)
+    _write_vectors(memory_engine.faiss_db.embedding_storage, [1, 2])
+    validator = IndexValidator(str(db_path), faiss_db=memory_engine.faiss_db)
+
+    result = await validator.rebuild_indexes(
+        memory_engine=memory_engine,
+        force_full_vector=True,
+    )
+
+    assert result["success"] is True
+    assert result["vector_mode"] == "full"
+    assert result["switched"] is True
+    assert provider.calls == [["doc-0", "doc-1"]]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_full_rebuild_resumes_from_shadow_checkpoint(tmp_path: Path):
+    db_path = tmp_path / "memory.db"
+    index_path = tmp_path / "memory.index"
+    _prepare_db(db_path, count=5)
+
+    class _BlockingProvider(_DummyEmbeddingProvider):
+        def __init__(self, block_second_call: bool):
+            super().__init__()
+            self.block_second_call = block_second_call
+            self.second_call_started = asyncio.Event()
+            self.release_second_call = asyncio.Event()
+
+        async def get_embeddings_batch(self, contents, **kwargs):
+            del kwargs
+            self.calls.append(list(contents))
+            if self.block_second_call and len(self.calls) == 2:
+                self.second_call_started.set()
+                await self.release_second_call.wait()
+            return [
+                [float(len(content)), float(index + 1)]
+                for index, content in enumerate(contents)
+            ]
+
+    first_provider = _BlockingProvider(block_second_call=True)
+    first_engine = _DummyMemoryEngine(db_path, index_path, first_provider, batch_size=2)
+    first_validator = IndexValidator(str(db_path), faiss_db=first_engine.faiss_db)
+
+    rebuild_task = asyncio.create_task(
+        first_validator.rebuild_indexes(
+            memory_engine=first_engine,
+            force_full_vector=True,
+        )
+    )
+    await asyncio.wait_for(first_provider.second_call_started.wait(), timeout=1)
+    rebuild_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await rebuild_task
+
+    checkpoint_path = Path(f"{index_path}.rebuild.tmp")
+    assert checkpoint_path.exists()
+    checkpoint = faiss.read_index(str(checkpoint_path))
+    assert checkpoint.ntotal == 2
+
+    resumed_provider = _BlockingProvider(block_second_call=False)
+    resumed_engine = _DummyMemoryEngine(
+        db_path, index_path, resumed_provider, batch_size=2
+    )
+    resumed_validator = IndexValidator(str(db_path), faiss_db=resumed_engine.faiss_db)
+
+    result = await resumed_validator.rebuild_indexes(
+        memory_engine=resumed_engine,
+        force_full_vector=True,
+    )
+
+    assert result["success"] is True
+    assert resumed_provider.calls == [["doc-2", "doc-3"], ["doc-4"]]
+    assert resumed_engine.faiss_db.embedding_storage.index.ntotal == 5
+    assert not checkpoint_path.exists()

--- a/tests/test_plugin_initializer.py
+++ b/tests/test_plugin_initializer.py
@@ -2,7 +2,9 @@
 Tests for PluginInitializer state management and provider resolution.
 """
 
+import asyncio
 import subprocess
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import astrbot_plugin_livingmemory.core.plugin_initializer as plugin_initializer_mod
@@ -106,6 +108,132 @@ def test_load_faiss_vec_db_class_uses_patched_class(monkeypatch, initializer):
     monkeypatch.setattr(plugin_initializer_mod, "FaissVecDB", FakeFaissVecDB)
 
     assert initializer._load_faiss_vec_db_class() is FakeFaissVecDB
+
+
+@pytest.mark.asyncio
+async def test_startup_index_rebuild_runs_in_background(initializer):
+    rebuild_started = asyncio.Event()
+    allow_rebuild_to_finish = asyncio.Event()
+
+    class _Validator:
+        async def get_migration_status(self):
+            return True, 120
+
+        async def rebuild_indexes(self, memory_engine, progress_callback=None):
+            del memory_engine
+            rebuild_started.set()
+            if progress_callback:
+                await progress_callback(50, 120, "halfway")
+            await allow_rebuild_to_finish.wait()
+            return {
+                "success": True,
+                "processed": 120,
+                "errors": 0,
+                "total": 120,
+                "partial": False,
+                "message": "done",
+            }
+
+    initializer.index_validator = _Validator()
+    initializer.memory_engine = SimpleNamespace(index_maintenance_status={})
+
+    await initializer._auto_rebuild_index_if_needed()
+    await asyncio.wait_for(rebuild_started.wait(), timeout=1)
+
+    assert initializer.index_maintenance_status["state"] == "rebuilding"
+    assert initializer.index_maintenance_status["current"] == 50
+    assert initializer._index_maintenance_task is not None
+    assert not initializer._index_maintenance_task.done()
+
+    task = initializer._index_maintenance_task
+    allow_rebuild_to_finish.set()
+    await task
+
+    assert initializer.index_maintenance_status["state"] == "ready"
+    assert initializer.index_maintenance_status["current"] == 120
+    assert initializer.memory_engine.index_maintenance_status["state"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_index_maintenance_reconciles_concurrent_writes_once(initializer):
+    inconsistent = SimpleNamespace(
+        is_consistent=False,
+        needs_rebuild=True,
+        reason="BM25索引缺失1条文档",
+    )
+    consistent = SimpleNamespace(
+        is_consistent=True,
+        needs_rebuild=False,
+        reason="索引状态正常",
+    )
+    rebuild_indexes = AsyncMock(
+        side_effect=[
+            {
+                "success": True,
+                "processed": 100,
+                "errors": 0,
+                "total": 100,
+                "partial": False,
+                "message": "first pass",
+            },
+            {
+                "success": True,
+                "processed": 1,
+                "errors": 0,
+                "total": 101,
+                "partial": False,
+                "message": "reconciled",
+            },
+        ]
+    )
+    initializer.index_validator = SimpleNamespace(
+        rebuild_indexes=rebuild_indexes,
+        check_consistency=AsyncMock(side_effect=[inconsistent, consistent]),
+    )
+    initializer.memory_engine = SimpleNamespace(index_maintenance_status={})
+
+    await initializer._run_scheduled_index_rebuild("repair", 100)
+
+    assert rebuild_indexes.await_count == 2
+    assert initializer.index_maintenance_status["state"] == "ready"
+    assert "reconciliation" in initializer.index_maintenance_status["result"]
+
+
+@pytest.mark.asyncio
+async def test_provider_change_rebuilds_document_and_graph_indexes(initializer):
+    consistent = SimpleNamespace(
+        is_consistent=True,
+        needs_rebuild=False,
+        reason="索引状态正常",
+        documents_count=3,
+    )
+    initializer.index_validator = SimpleNamespace(
+        provider_fingerprint_changed=AsyncMock(return_value=True),
+        check_consistency=AsyncMock(return_value=consistent),
+        rebuild_indexes=AsyncMock(
+            return_value={
+                "success": True,
+                "processed": 3,
+                "errors": 0,
+                "total": 3,
+                "partial": False,
+                "message": "done",
+            }
+        ),
+    )
+    initializer.memory_engine = SimpleNamespace(
+        index_maintenance_status={},
+        rebuild_graph_index=AsyncMock(return_value={"rebuilt": 3, "skipped": 0}),
+    )
+
+    await initializer._run_index_maintenance()
+
+    initializer.memory_engine.rebuild_graph_index.assert_awaited_once()
+    assert initializer.index_maintenance_status["state"] == "ready"
+    assert initializer.index_maintenance_status["result"]["graph_rebuild"] == {
+        "rebuilt": 3,
+        "skipped": 0,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- move startup index validation and repair to a cancellable background maintenance task
- rebuild BM25, document vectors, and graph data through shadow generations with safe switching
- resume interrupted vector rebuilds, detect embedding provider changes, and reconcile concurrent writes
- exclude archived memories and expose maintenance progress through `/lmem status`

## Related Issues

- No direct issue; addresses the large-index initialization failure mode found during lifecycle review.

## Changes

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [x] Tests
- [ ] Configuration / release metadata

## Testing

- [x] `uv run pytest -q` (705 passed)
- [x] `uv run ruff check` on all changed Python files
- [x] JSON validation and `git diff --check`

## Checklist

- [x] I have searched existing issues and pull requests.
- [x] Documentation or configuration schema changes are not required.
- [x] Release metadata will be updated in the dedicated release commit after this PR is merged.
- [x] I have added or updated tests for behavior changes.