### PR TITLE
fix(init): diagnose FAISS binding mismatch

### DIFF
--- a/core/plugin_initializer.py
+++ b/core/plugin_initializer.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from importlib import metadata
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,19 @@ from .schedulers.decay_scheduler import DecayScheduler
 from .validators.index_validator import IndexValidator
 
 FaissVecDB: Any = None
+
+_FAISS_GENERIC_FALLBACK_MARKERS = (
+    "illegal instruction",
+    "optimized",
+    "avx",
+    "simd",
+    "dll load failed",
+    "cannot open shared object file",
+    "could not load library",
+    "image not found",
+    "symbol not found",
+    "undefined symbol",
+)
 
 # ── Faiss C++ fopen() 在 Windows 上使用 ANSI codepage ──
 # Python 传给 Faiss 的路径是 UTF-8 字节，Windows fopen 期望 ANSI 编码，
@@ -80,6 +94,38 @@ def _sanitize_path(path: str) -> str:
         elif not parts or parts[-1] != "[***]":
             parts.append("[***]")
     return "".join(parts)
+
+
+def _faiss_error_details(result: subprocess.CompletedProcess[str]) -> str:
+    """Extract useful diagnostics from a FAISS import probe."""
+    details = (result.stderr or result.stdout or "").strip()
+    if result.returncode < 0:
+        details = f"进程被信号 {-result.returncode} 终止。{details}".strip()
+    return details
+
+
+def _is_faiss_binding_mismatch(details: str) -> bool:
+    """Identify known Python-wrapper/binary-extension mismatches."""
+    lowered = details.lower()
+    return "superkmeans" in lowered or (
+        "python binding" in lowered and "mismatch" in lowered
+    )
+
+
+def _should_try_faiss_generic(result: subprocess.CompletedProcess[str]) -> bool:
+    """Return whether a generic-instruction-set probe can plausibly help."""
+    if result.returncode < 0:
+        return True
+    details = _faiss_error_details(result).lower()
+    return any(marker in details for marker in _FAISS_GENERIC_FALLBACK_MARKERS)
+
+
+def _installed_faiss_version() -> str:
+    """Read package metadata without importing a potentially broken FAISS module."""
+    try:
+        return metadata.version("faiss-cpu")
+    except metadata.PackageNotFoundError:
+        return "未知"
 
 
 class PluginInitializer:
@@ -384,9 +430,27 @@ class PluginInitializer:
         if result.returncode == 0:
             return
 
+        details = _faiss_error_details(result)
+        if _is_faiss_binding_mismatch(details):
+            version = _installed_faiss_version()
+            raise InitializationError(
+                "FAISS 初始化失败：Python 封装与二进制扩展不匹配"
+                f"（检测到 faiss-cpu {version}）。这不是 Embedding Provider 配置问题。"
+                "AstrBot Desktop 用户请升级或修复内置 Python 环境；"
+                "请避免 faiss-cpu 1.14.2，并在同一环境中干净重装兼容版本"
+                "（建议 1.14.3 或更高版本）。"
+                f"{' 原始错误: ' + details if details else ''}"
+            )
+
+        if not _should_try_faiss_generic(result):
+            raise InitializationError(
+                "FAISS 初始化失败，faiss-cpu 无法在当前 Python 环境中加载。"
+                "请检查安装是否完整，并确保 Python 封装与二进制扩展来自同一版本。"
+                f"{' 原始错误: ' + details if details else ''}"
+            )
+
         # Some faiss-cpu wheels select an optimized extension that is incompatible
-        # with the current CPU or mismatched with the installed Python wrappers.
-        # Probe the generic extension in a child process before changing this process.
+        # with the current CPU. Probe the generic extension before changing this process.
         generic_env = os.environ.copy()
         generic_env["FAISS_OPT_LEVEL"] = "generic"
         try:
@@ -408,13 +472,8 @@ class PluginInitializer:
             )
             return
 
-        details = (result.stderr or result.stdout or "").strip()
-        if result.returncode < 0:
-            details = f"进程被信号 {-result.returncode} 终止。{details}".strip()
         if generic_result is not None:
-            generic_details = (
-                generic_result.stderr or generic_result.stdout or ""
-            ).strip()
+            generic_details = _faiss_error_details(generic_result)
             if generic_details and generic_details != details:
                 details = f"{details}；generic 模式: {generic_details}".strip("；")
         raise InitializationError(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-faiss-cpu>=1.7.0
+faiss-cpu>=1.12.0,!=1.14.2
 networkx>=3.0
 jieba>=0.42.1
 pytz>=2021.3

--- a/tests/test_plugin_initializer.py
+++ b/tests/test_plugin_initializer.py
@@ -4,6 +4,7 @@ Tests for PluginInitializer state management and provider resolution.
 
 import asyncio
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -81,8 +82,35 @@ def test_check_faiss_runtime_raises_actionable_error(monkeypatch, initializer):
         plugin_initializer_mod.subprocess, "run", Mock(return_value=result)
     )
 
-    with pytest.raises(InitializationError, match="FAISS 初始化失败"):
+    with pytest.raises(InitializationError, match="CPU 或运行环境可能不兼容"):
         initializer._check_faiss_runtime()
+
+
+def test_check_faiss_runtime_reports_binding_mismatch(monkeypatch, initializer):
+    result = subprocess.CompletedProcess(
+        args=[],
+        returncode=1,
+        stdout="",
+        stderr=(
+            "NameError: name 'SuperKMeans' is not defined. "
+            "Did you mean: 'SuperKmeans'?"
+        ),
+    )
+    run = Mock(return_value=result)
+    monkeypatch.setattr(plugin_initializer_mod.subprocess, "run", run)
+    monkeypatch.setattr(
+        plugin_initializer_mod.metadata, "version", Mock(return_value="1.14.2")
+    )
+
+    with pytest.raises(InitializationError) as exc_info:
+        initializer._check_faiss_runtime()
+
+    message = str(exc_info.value)
+    assert "faiss-cpu 1.14.2" in message
+    assert "不是 Embedding Provider 配置问题" in message
+    assert "AstrBot Desktop" in message
+    assert "1.14.3" in message
+    assert run.call_count == 1
 
 
 def test_check_faiss_runtime_falls_back_to_generic(monkeypatch, initializer):
@@ -99,6 +127,12 @@ def test_check_faiss_runtime_falls_back_to_generic(monkeypatch, initializer):
     assert plugin_initializer_mod.os.environ["FAISS_OPT_LEVEL"] == "generic"
     assert run.call_count == 2
     assert run.call_args_list[1].kwargs["env"]["FAISS_OPT_LEVEL"] == "generic"
+
+
+def test_requirements_excludes_broken_faiss_release():
+    requirements = (Path(__file__).parents[1] / "requirements.txt").read_text()
+
+    assert "faiss-cpu>=1.12.0,!=1.14.2" in requirements.splitlines()
 
 
 def test_load_faiss_vec_db_class_uses_patched_class(monkeypatch, initializer):


### PR DESCRIPTION
## Summary

- exclude the known-broken `faiss-cpu 1.14.2` release while keeping compatible 1.12+ installs
- detect the `SuperKMeans` Python wrapper/binary mismatch before attempting an ineffective generic CPU fallback
- report the installed FAISS version and actionable AstrBot Desktop repair guidance
- keep the generic fallback for actual instruction-set and dynamic-library failures

## Related Issues

- Closes #198
- Related: AstrBotDevs/AstrBot#9392

## Changes

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Tests
- [x] Configuration / release metadata

## Testing

- [x] `uv run pytest -q` (707 passed)
- [x] `uv run ruff check core/plugin_initializer.py tests/test_plugin_initializer.py`

## Checklist

- [x] I have searched existing issues and pull requests.
- [x] I have updated documentation or configuration schema when needed.
- [x] No plugin version change is included in this fix PR.
- [x] I have added or updated tests for behavior changes.
