### PR TITLE
fix(deps): update PostCSS to 8.5.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2116,9 +2116,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2174,9 +2174,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2194,7 +2194,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary

- update the transitive documentation build dependency `postcss` from `8.5.15` to `8.5.25`
- update its required `nanoid` dependency from `3.3.12` to `3.3.16`
- resolve Dependabot alert #4 / GHSA-r28c-9q8g-f849

## Security

PostCSS versions through 8.5.17 can load previous source maps outside the CSS source directory. This dependency is development-only and used by the VitePress documentation build, but the vulnerable lockfile entry should still be removed.

## Changes

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tests
- [x] Configuration / release metadata

## Testing

- [x] `npm ci --registry=https://registry.npmjs.org`
- [x] `npm run docs:build`
- [x] `npm audit --package-lock-only --audit-level=high --registry=https://registry.npmjs.org` (0 vulnerabilities)

## Checklist

- [x] The lockfile diff is limited to PostCSS and its Nano ID dependency.
- [x] No plugin runtime dependency or plugin version changed.
- [x] The documentation site builds successfully.
