### PR TITLE
fix(conversation): preserve Bot identity in private chats

### DIFF
--- a/core/managers/conversation_manager.py
+++ b/core/managers/conversation_manager.py
@@ -102,6 +102,11 @@ class ConversationManager:
         """
         # 使用 unified_msg_origin 作为会话ID，确保多Bot场景下的唯一性
         session_id = event.unified_msg_origin
+        platform = (
+            event.get_platform_name()
+            if hasattr(event, "get_platform_name")
+            else "unknown"
+        )
 
         # 提取发送者信息
         sender_id = None
@@ -136,18 +141,10 @@ class ConversationManager:
             if is_group:
                 group_id = session_id  # 群聊时session_id即为group_id
 
-        # 群聊中助手消息：sender_name 使用 Bot 自身昵称（如果可获取）
+        # 助手消息必须使用 Bot 自身身份，不能继承触发事件中的用户身份。
         is_bot_message = role == "assistant"
-        if is_bot_message and is_group:
-            bot_name = None
-            if hasattr(event, "get_self_id"):
-                bot_name = event.get_self_id()
-            # 尝试从 context 获取 Bot 昵称（AstrBot 通常在 message_obj 中有 self_id）
-            if hasattr(event, "message_obj") and hasattr(event.message_obj, "self_id"):
-                bot_name = str(event.message_obj.self_id)
-            if bot_name:
-                sender_id = bot_name
-                sender_name = sender_name or bot_name
+        if is_bot_message:
+            sender_id, sender_name = self._resolve_bot_identity(event, str(platform))
 
         # 调试日志：记录最终获取到的发送者信息
         logger.debug(
@@ -156,12 +153,6 @@ class ConversationManager:
             f"role={role}, is_group={is_group}, group_id={group_id}"
         )
 
-        # 获取平台名称（字符串）
-        platform = (
-            event.get_platform_name()
-            if hasattr(event, "get_platform_name")
-            else "unknown"
-        )
         if role == "user":
             sender_name = resolve_sender_alias(
                 self.identity_aliases,
@@ -265,6 +256,51 @@ class ConversationManager:
         if isinstance(obj, dict):
             return obj.get(key)
         return getattr(obj, key, None)
+
+    @classmethod
+    def _call_event_getter(cls, event, method_name: str):
+        getter = getattr(event, method_name, None)
+        if not callable(getter):
+            return None
+        try:
+            return getter()
+        except Exception as exc:
+            logger.debug(f"读取事件方法 {method_name} 失败: {exc}")
+            return None
+
+    @classmethod
+    def _resolve_bot_identity(cls, event, platform: str) -> tuple[str, str]:
+        """Resolve a Bot identity without falling back to the triggering user."""
+        message_obj = getattr(event, "message_obj", None)
+        raw_message = getattr(message_obj, "raw_message", None)
+
+        bot_id = None
+        for candidate in (
+            cls._call_event_getter(event, "get_self_id"),
+            cls._raw_get(message_obj, "self_id"),
+            cls._raw_get(raw_message, "self_id"),
+        ):
+            bot_id = cls._normalize_sender_name(candidate)
+            if bot_id:
+                break
+
+        bot_name = None
+        for source in (event, message_obj, raw_message):
+            for key in ("bot_name", "bot_nickname", "self_name"):
+                bot_name = cls._normalize_sender_name(cls._raw_get(source, key))
+                if bot_name:
+                    break
+            if bot_name:
+                break
+
+        if bot_id:
+            return bot_id, bot_name or bot_id
+
+        platform_id = cls._normalize_sender_name(
+            cls._call_event_getter(event, "get_platform_id")
+        )
+        fallback_scope = platform_id or cls._normalize_sender_name(platform) or "unknown"
+        return f"bot:{fallback_scope}", bot_name or "Bot"
 
     @classmethod
     def _format_raw_user_name(cls, raw_user, sender_id: str | None) -> str | None:

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -15,9 +15,15 @@ from astrbot.api.platform import MessageType
 
 
 class _DummyEvent:
-    def __init__(self, session_id: str, group: bool = False):
+    def __init__(
+        self,
+        session_id: str,
+        group: bool = False,
+        self_id: str = "bot-1",
+    ):
         self.unified_msg_origin = session_id
         self._group = group
+        self.self_id = self_id
         self.sender_id = "u1"
         self.sender_name = "Tester"
 
@@ -26,6 +32,12 @@ class _DummyEvent:
 
     def get_sender_name(self):
         return "Tester"
+
+    def get_self_id(self):
+        return self.self_id
+
+    def get_platform_id(self):
+        return "test-instance"
 
     def get_message_type(self):
         return MessageType.GROUP_MESSAGE if self._group else MessageType.FRIEND_MESSAGE
@@ -76,8 +88,18 @@ async def test_conversation_manager_add_and_get_context(tmp_path: Path):
     manager = ConversationManager(store=store, max_cache_size=2, context_window_size=10)
 
     event = _DummyEvent("test:private:s1", group=False)
-    await manager.add_message_from_event(event, role="user", content="hello")
-    await manager.add_message_from_event(event, role="assistant", content="world")
+    user_message = await manager.add_message_from_event(
+        event, role="user", content="hello"
+    )
+    assistant_message = await manager.add_message_from_event(
+        event, role="assistant", content="world"
+    )
+
+    assert user_message.sender_id == "u1"
+    assert user_message.sender_name == "Tester"
+    assert assistant_message.sender_id == "bot-1"
+    assert assistant_message.sender_name == "bot-1"
+    assert assistant_message.metadata == {"is_bot_message": True}
 
     context = await manager.get_context("test:private:s1")
     assert len(context) == 2
@@ -90,6 +112,43 @@ async def test_conversation_manager_add_and_get_context(tmp_path: Path):
     assert session is not None
     assert session.message_count == 2
 
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_private_assistant_uses_explicit_bot_fallback_without_self_id(
+    tmp_path: Path,
+):
+    store = ConversationStore(str(tmp_path / "bot-fallback.db"))
+    await store.initialize()
+    manager = ConversationManager(store=store)
+    event = _DummyEvent("test:private:s-fallback", self_id="")
+
+    message = await manager.add_message_from_event(
+        event, role="assistant", content="world"
+    )
+
+    assert message.sender_id == "bot:test-instance"
+    assert message.sender_name == "Bot"
+    assert message.group_id is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_group_assistant_replaces_user_name_with_bot_name(tmp_path: Path):
+    store = ConversationStore(str(tmp_path / "group-bot.db"))
+    await store.initialize()
+    manager = ConversationManager(store=store)
+    event = _DummyEvent("test:group:g1", group=True)
+    event.bot_name = "LivingMemory Bot"
+
+    message = await manager.add_message_from_event(
+        event, role="assistant", content="world"
+    )
+
+    assert message.sender_id == "bot-1"
+    assert message.sender_name == "LivingMemory Bot"
+    assert message.group_id == "test:group:g1"
     await store.close()
 
 

--- a/tests/test_memory_scope.py
+++ b/tests/test_memory_scope.py
@@ -25,12 +25,14 @@ class _Event:
         sender_name: str = "Original Name",
         platform: str = "test",
         group_id: str = "",
+        self_id: str = "bot-1",
     ) -> None:
         self.unified_msg_origin = session_id
         self.sender_id = sender_id
         self.sender_name = sender_name
         self.platform = platform
         self.group_id = group_id
+        self.self_id = self_id
 
     def get_sender_id(self):
         return self.sender_id
@@ -40,6 +42,12 @@ class _Event:
 
     def get_platform_name(self):
         return self.platform
+
+    def get_platform_id(self):
+        return f"{self.platform}-instance"
+
+    def get_self_id(self):
+        return self.self_id
 
     def get_group_id(self):
         return self.group_id
@@ -186,5 +194,6 @@ async def test_conversation_manager_applies_user_alias_only_to_user_messages(tmp
     assistant_message = await manager.add_message_from_event(event, "assistant", "hi")
 
     assert user_message.sender_name == "Canonical Name"
-    assert assistant_message.sender_name == "Original Name"
+    assert assistant_message.sender_id == "bot-1"
+    assert assistant_message.sender_name == "bot-1"
     await store.close()


### PR DESCRIPTION
## Summary

- resolve assistant message identity from the Bot `self_id` in both private and group conversations
- replace the triggering user's display name with an available Bot name or the Bot ID
- use an explicit platform-scoped Bot fallback when an adapter does not expose `self_id`
- keep user identity aliases limited to user messages

## Related Issues

- Closes #232

## Changes

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Tests
- [ ] Configuration / release metadata

## Testing

- [x] `uv run pytest -q` (709 passed)
- [x] `uv run ruff check core/managers/conversation_manager.py tests/test_conversation_manager.py`
- [x] Private chat, group chat, user alias, and missing-`self_id` regression coverage

## Compatibility

Existing incorrectly attributed rows are left unchanged because they do not contain enough information to reconstruct the historical Bot identity safely. New assistant messages use the corrected identity after upgrade.
