### PR TITLE
docs(readme): surface recent capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@
 | **混合检索**<br>关键词与语义检索覆盖两条数据路径。 | **双通道总结**<br>事实信息与人格上下文保持独立价值。 | **安全操作**<br>自动备份、事务删除与重建失败回滚。 |
 | **Agent 原生工具**<br>`recall_long_term_memory` 与 `memorize_long_term_memory`。 | **时间感知图谱**<br>关系置信度随证据累积或消退动态变化。 | **专注的管理界面**<br>管理记忆、调试召回并检查完整图谱。 |
 
+## 近期能力
+
+| 可恢复记忆 | 可控边界 | 在线维护 |
+| :--- | :--- | :--- |
+| **原文与归档**<br>重要记忆可保留来源消息，支持核验、重新总结；低价值记忆可归档并恢复，而非直接删除。 | **作用域与访问控制**<br>可按会话、用户或全局共享记忆，并通过强制隔离、白名单和身份别名明确边界。 | **安全索引重建**<br>启动检查和大规模修复在后台运行，使用分批重建、进度状态、失败回滚和影子索引切换。 |
+
 ```mermaid
 flowchart LR
     A[对话] --> B[总结]
@@ -63,7 +69,7 @@ flowchart LR
 
 | 入门 | 配置 | 使用 | 原理 |
 | :--- | :--- | :--- | :--- |
-| [快速开始](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/guide/getting-started) | [完整配置](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/configuration) | [命令列表](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/commands) | [技术架构](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/architecture) |
+| [快速开始](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/guide/getting-started)<br>[功能全览](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/features) | [完整配置](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/configuration) | [命令列表](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/commands)<br>[WebUI 管理](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/webui) | [技术架构](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/architecture) |
 
 从 v1.4.0-v1.4.2 升级？请先检查[备份、迁移与清理配置](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/configuration#备份迁移与清理)。
 

--- a/README_en.md
+++ b/README_en.md
@@ -36,6 +36,12 @@
 | **Hybrid retrieval**<br>Keyword and semantic search across two routes. | **Dual summaries**<br>Facts and persona context remain independently useful. | **Safe operations**<br>Backups, transactional deletion, and rebuild rollback. |
 | **Agent-native tools**<br>`recall_long_term_memory` and `memorize_long_term_memory`. | **Temporal graph**<br>Confidence evolves as evidence accumulates or fades. | **Focused dashboard**<br>Manage memory, debug recall, and inspect the full graph. |
 
+## Recent capabilities
+
+| Recoverable memory | Controlled boundaries | Online maintenance |
+| :--- | :--- | :--- |
+| **Sources and archives**<br>Important memories can retain source messages for review and re-summarization; low-value memories can be archived and restored instead of deleted. | **Scopes and access control**<br>Share memory by session, user, or globally, with explicit isolation, allowlists, and identity aliases. | **Safe index rebuilds**<br>Startup checks and large repairs run in the background with batching, progress status, rollback, and shadow-index cutover. |
+
 ```mermaid
 flowchart LR
     A[Conversation] --> B[Summarize]
@@ -63,7 +69,7 @@ Open the visual workspace at `Plugins -> LivingMemory -> Pages -> dashboard`. Pl
 
 | Learn | Configure | Operate | Understand |
 | :--- | :--- | :--- | :--- |
-| [Quick start](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/guide/getting-started) | [Configuration](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/configuration) | [Commands](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/commands) | [Architecture](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/architecture) |
+| [Quick start](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/guide/getting-started)<br>[Feature overview](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/features) | [Configuration](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/configuration) | [Commands](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/commands)<br>[WebUI guide](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/webui) | [Architecture](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/architecture) |
 
 Upgrading from v1.4.0-v1.4.2? Review the [backup and migration settings](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/configuration#backup-migration-and-cleanup) first.
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -36,6 +36,12 @@
 | **Гибридный поиск**<br>Ключевые слова и семантика в двух контурах. | **Два вида сводок**<br>Факты и контекст личности сохраняют отдельную ценность. | **Безопасные операции**<br>Резервные копии, транзакционное удаление и откат. |
 | **Инструменты для Agent**<br>`recall_long_term_memory` и `memorize_long_term_memory`. | **Временной граф**<br>Достоверность связей меняется по мере накопления и затухания свидетельств. | **Сфокусированная панель**<br>Управление памятью, отладка поиска и просмотр полного графа. |
 
+## Новые возможности
+
+| Восстанавливаемая память | Управляемые границы | Обслуживание без остановки |
+| :--- | :--- | :--- |
+| **Исходные сообщения и архив**<br>Для важных воспоминаний можно сохранить исходные сообщения, проверить их и повторно создать сводку; малоценные записи можно архивировать и восстанавливать. | **Области и контроль доступа**<br>Память можно разделять по диалогу, пользователю или глобально, используя принудительную изоляцию, белые списки и псевдонимы. | **Безопасная перестройка индексов**<br>Проверки и крупные исправления выполняются в фоне с пакетной обработкой, отображением прогресса, откатом и теневыми индексами. |
+
 ```mermaid
 flowchart LR
     A[Диалог] --> B[Сводка]
@@ -63,7 +69,7 @@ flowchart LR
 
 | Начало работы | Настройка | Команды | Архитектура |
 | :--- | :--- | :--- | :--- |
-| [Краткое руководство](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/guide/getting-started) | [Конфигурация](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/configuration) | [Список команд](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/commands) | [Устройство системы](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/architecture) |
+| [Краткое руководство](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/guide/getting-started)<br>[Обзор функций](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/features) | [Конфигурация](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/configuration) | [Список команд](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/commands)<br>[Руководство WebUI](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/webui) | [Устройство системы](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/architecture) |
 
 Обновляетесь с v1.4.0-v1.4.2? Сначала проверьте [настройки резервного копирования и миграции](https://lxfight-s-astrbot-plugins.github.io/astrbot_plugin_livingmemory/en/configuration#backup-migration-and-cleanup).
 


### PR DESCRIPTION
## Summary

- surface recoverable memory, access boundaries, and online index maintenance on the repository homepage
- add direct feature-overview and WebUI-guide links
- keep Chinese, English, and Russian README pages aligned

## Verification

- `npm run docs:build`
- `git diff --check`

## Scope

README discovery only. Detailed feature and operations documentation is intentionally handled in follow-up PRs.
