### PR TITLE
fix(session): handle renamed reset signal

### DIFF
--- a/main.py
+++ b/main.py
@@ -359,7 +359,10 @@ class LivingMemoryPlugin(Star):
     @filter.after_message_sent()
     async def handle_session_reset(self, event: AstrMessageEvent, *_args):
         """[Event Hook] After message sent, check if plugin session context needs clearing (/reset or /new)"""
-        if not event.get_extra("_clean_ltm_session", False):
+        if not (
+            event.get_extra("_clean_group_context_session", False)
+            or event.get_extra("_clean_ltm_session", False)
+        ):
             return
 
         ready, _ = await self._ensure_plugin_ready()


### PR DESCRIPTION
Accept AstrBot's current group-context cleanup signal while preserving compatibility with the legacy long-term-memory signal.

## Summary
`AstrBot`从`4.25.2`开始，`/reset`和`/new`由`_clean_ltm_session`变为`_clean_group_context_session`

具体提交为[95d8057](https://github.com/AstrBotDevs/AstrBot/commit/95d80578bf9234036eb74e9d03ea4a8be2a49657)

这导致 issue 70 的 regression，本提交现在同时监听新旧清理信号

## Related Issues

- Closes #70 

## Changes

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Tests
- [ ] Configuration / release metadata

## Testing

- [x] `uv run pytest -q`
- [x] Manual verification:

## Checklist

- [x] I have searched existing issues and pull requests.
- [x] I have updated documentation or configuration schema when needed.
- [x] I have updated `metadata.yaml`, `main.py`, `CHANGELOG.md`, and version constants when this changes the released plugin version.
- [x] I have added or updated tests for behavior changes.
