### PR TITLE
fix(webui): stored XSS via attribute escaping, virtual scroll drift, and interaction races

### DIFF
--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -160,6 +160,9 @@ import {
       fetchGraphStats();
       if (window.ensureGraphScene) window.ensureGraphScene();
     }
+    if (window.Graph2D && typeof window.Graph2D.setActive === "function") {
+      window.Graph2D.setActive(name === "graph");
+    }
     if (name === "memory") memoryPage.fetch();
     if (name === "recall") { /* 召回页面按需加载 */ }
     if (name === "system") systemPage.fetch();
@@ -318,7 +321,7 @@ import {
 
     document.addEventListener("keydown", (e) => {
       if (e.key === "Escape") {
-        peekPanel.close();
+        peekPanel.handleEscape();
       }
     });
     window.addEventListener("languagechange", refreshDynamicI18n);

--- a/pages/dashboard/graph-2d.js
+++ b/pages/dashboard/graph-2d.js
@@ -143,6 +143,7 @@
     this.interaction = interaction;
     this._running = false;
     this._rafId = null;
+    this._pageVisible = true;
     this._nodes = [];
     this._edges = [];
     this._nodeMap = {};
@@ -234,6 +235,20 @@
   Animator.prototype.stop = function() {
     this._running = false;
     if (this._rafId !== null) { cancelAnimationFrame(this._rafId); this._rafId = null; }
+  };
+
+  /**
+   * 页面可见性开关：SPA 切页只改 CSS display，RAF 循环不会自动停，
+   * 离开图谱页时必须显式停下氛围动画，回来时再恢复
+   * @param {boolean} visible - 图谱页当前是否可见
+   */
+  Animator.prototype.setPageVisible = function(visible) {
+    this._pageVisible = !!visible;
+    if (visible) {
+      this.start();
+    } else {
+      this.stop();
+    }
   };
 
   Animator.prototype.setData = function(nodes, edges) {
@@ -431,6 +446,13 @@
   Animator.prototype._tick = function() {
     if (!this._running) return;
     this._rafId = null;
+
+    /* 页面隐藏（SPA 切到其他 tab 页）时停止循环：布局计算（Worker）仍在
+       后台继续，返回图谱页时 setPageVisible(true) 会恢复渲染。 */
+    if (!this._pageVisible) {
+      this._running = false;
+      return;
+    }
 
     /* 布局未收敛（渐进 / Worker 布局进行中）：不渲染中间态、不做环境
        漂浮——此阶段 layout targets 尚为空，漂浮会把节点向原点拉扯并与
@@ -700,6 +722,15 @@
     this.animator.recenter(null);
   };
 
+  /**
+   * SPA 切页时由 app.switchPage 调用：离开图谱页停止 RAF 循环（省 CPU），
+   * 回到图谱页恢复
+   * @param {boolean} active - 图谱页是否可见
+   */
+  Graph2D.prototype.setActive = function(active) {
+    if (this.animator) this.animator.setPageVisible(active);
+  };
+
   Graph2D.prototype.resize = function() {
     if (this.renderer) this.renderer.resize();
     if (this.animator) {
@@ -710,6 +741,7 @@
   };
 
   Graph2D.prototype.destroy = function() {
+    this.animator.setPageVisible(false);
     if (this.animator) this.animator.stop();
     if (this.canvas && this.canvas.parentElement) {
       this.canvas.parentElement.removeChild(this.canvas);

--- a/pages/dashboard/graph-renderer.js
+++ b/pages/dashboard/graph-renderer.js
@@ -58,6 +58,8 @@
     this._labelWidthCache = {};
     this._communityCacheKey = null;
     this._communityCache = null;
+    // 粒子相位按边 id 累积，换图后旧 id 永不复用，需随数据一并重置
+    this._particleOffsets = {};
     nodes.forEach(function(node) {
       self._adjacency[node.id] = [];
       self._nodeEdges[node.id] = [];

--- a/pages/dashboard/graph-ui.js
+++ b/pages/dashboard/graph-ui.js
@@ -198,7 +198,7 @@
       state.overviewMode = fullGraph ? "full" : "limited";
       setOverviewButtonLabel();
       renderPayload(payload, true);
-      if (window.lmFetchGraphStats) window.lmFetchGraphStats();
+      // 统计卡片由 renderPayload 内部统一刷新，此处不再重复请求
     } catch (e) {
       setCanvasMessage(e.message || window.t("graph.errorFetch"), false);
     } finally {
@@ -220,6 +220,7 @@
   }
 
   async function runQuery() {
+    if (state.isLoading) return; // 回车触发绕过按钮 disabled，显式防并发
     var query = dom.queryInput.value.trim();
     if (!query) { fetchOverview(false); return; }
 
@@ -242,6 +243,7 @@
   }
 
   async function focusMemory() {
+    if (state.isLoading) return;
     var text = dom.memoryInput.value.trim();
     if (!text) { setCanvasMessage(window.t("graph.focusEmpty"), false); return; }
     var memoryId = Number.parseInt(text, 10);

--- a/pages/dashboard/modules/api-client.js
+++ b/pages/dashboard/modules/api-client.js
@@ -67,7 +67,9 @@ export class ApiClient {
   async request(path, options = {}) {
     const method = options.method || "GET";
     const body = options.body;
-    const retries = options.retries ?? 2;
+    // GET 幂等可安全重试；POST 可能非幂等（如 memories/update 重建新 ID），
+    // 超时重试会造成重复创建，默认不重试，调用方显式传 retries 才重试
+    const retries = options.retries ?? (method === "GET" ? 2 : 0);
 
     if (!this.bridge) {
       throw new Error(window.t ? window.t("bridge.error") : "Bridge not available");

--- a/pages/dashboard/modules/memory-page.js
+++ b/pages/dashboard/modules/memory-page.js
@@ -46,7 +46,15 @@ export class MemoryPage {
       const data = await this.api.get("memories", params);
       if (fetchGeneration !== this._fetchGeneration) return;
 
-      this.state.memory.total = data.total || 0;
+      // 删除/筛选后当前页可能超出总页数，回退到最后一页重取，避免显示假空表
+      const total = data.total || 0;
+      const totalPages = Math.max(1, Math.ceil(total / this.state.memory.pageSize));
+      if (this.state.memory.page > totalPages && !(data.items || []).length) {
+        this.state.memory.page = totalPages;
+        return this.fetch();
+      }
+
+      this.state.memory.total = total;
       this.state.memory.hasMore = data.has_more || false;
 
       this.state.memory.items = (Array.isArray(data.items) ? data.items : []).map(item => ({
@@ -122,16 +130,19 @@ export class MemoryPage {
       return;
     }
 
-    const totalHeight = this.state.memory.items.length * this.ROW_HEIGHT;
+    // 行高用实测值：CSS 的 td height 只是最小值，双行摘要单元格实际 ~63px，
+    // 硬编码 56px 会让 spacer 逐行漂移、末尾行不可达
+    const rowHeight = this._measuredRowHeight || this.ROW_HEIGHT;
+    const totalHeight = this.state.memory.items.length * rowHeight;
     const scrollTop = scrollEl ? scrollEl.scrollTop : 0;
     const viewHeight = scrollEl ? scrollEl.clientHeight : 600;
-    const start = Math.max(0, Math.floor(scrollTop / this.ROW_HEIGHT) - this.SCROLL_BUFFER);
+    const start = Math.max(0, Math.floor(scrollTop / rowHeight) - this.SCROLL_BUFFER);
     const end = Math.min(
       this.state.memory.items.length,
-      Math.ceil((scrollTop + viewHeight) / this.ROW_HEIGHT) + this.SCROLL_BUFFER
+      Math.ceil((scrollTop + viewHeight) / rowHeight) + this.SCROLL_BUFFER
     );
-    const padTop = start * this.ROW_HEIGHT;
-    const padBottom = totalHeight - end * this.ROW_HEIGHT;
+    const padTop = start * rowHeight;
+    const padBottom = totalHeight - end * rowHeight;
     const spacerRow = (height) => height > 0
       ? '<tr class="virtual-spacer" aria-hidden="true" style="height:' + height + 'px"><td colspan="7" style="height:' + height + 'px;padding:0;border:0"></td></tr>'
       : "";
@@ -164,7 +175,30 @@ export class MemoryPage {
     tbody.innerHTML = html + spacerRow(padBottom);
     tbody.style.paddingTop = "0";
     tbody.style.paddingBottom = "0";
+    this._measureRowHeight(tbody, rowHeight);
     this.updateSelectionControls();
+  }
+
+  /**
+   * 首个可见行渲染后实测行高，与假设不符时重算一次虚拟窗口
+   * @param {HTMLElement} tbody - 表格主体
+   * @param {number} assumed - 本次渲染假设的行高
+   */
+  _measureRowHeight(tbody, assumed) {
+    if (this._remeasuring) return;
+    if (!tbody || typeof tbody.querySelector !== "function") return;
+    const row = tbody.querySelector("tr[data-key]");
+    if (!row) return;
+    const h = row.offsetHeight;
+    if (h > 0 && Math.abs(h - assumed) > 0.5) {
+      this._measuredRowHeight = h;
+      this._remeasuring = true;
+      try {
+        this.renderVirtualSlice();
+      } finally {
+        this._remeasuring = false;
+      }
+    }
   }
 
   /**

--- a/pages/dashboard/modules/peek-panel.js
+++ b/pages/dashboard/modules/peek-panel.js
@@ -19,6 +19,8 @@ export class PeekPanel {
     this.state = state;
     this.api = apiClient;
     this._confirmResolve = null;
+    this._batchEditResolve = null;
+    this._detailGeneration = 0;
     this._prevPeekContent = null;
   }
 
@@ -47,6 +49,10 @@ export class PeekPanel {
     if (this._confirmResolve) {
       this._closeConfirmDialog(false);
     }
+    // 批量编辑对话框同理，否则其 promise 永远 pending（闭包泄漏）
+    if (this._batchEditResolve) {
+      this._closeBatchEditDialog(null);
+    }
     const panel = document.getElementById("peek-panel");
     panel.classList.remove("visible", "wide");
     panel.setAttribute("inert", "");
@@ -56,6 +62,36 @@ export class PeekPanel {
     this.state.isEditing = false;
     this.state._detailCache = null;
     this.state._nodeDetailCache = null;
+    // 使在途详情请求失效，防止面板关闭后被慢响应重新打开
+    this._detailGeneration++;
+  }
+
+  /**
+   * Escape 键的分层处理：批量编辑对话框 > 确认对话框 > 编辑态 > 面板本身。
+   * 编辑态直接关闭会静默丢弃未保存的修改，先回退到详情视图。
+   * @returns {boolean} 是否消费了该事件
+   */
+  handleEscape() {
+    if (this._batchEditResolve) {
+      this._closeBatchEditDialog(null);
+      return true;
+    }
+    if (this._confirmResolve) {
+      this._closeConfirmDialog(false);
+      return true;
+    }
+    const panel = document.getElementById("peek-panel");
+    if (!panel.classList.contains("visible")) return false;
+    if (this.state.isEditing) {
+      if (this.state._detailCache) {
+        this.renderDetailView(this.state._detailCache);
+      } else {
+        this.close();
+      }
+      return true;
+    }
+    this.close();
+    return true;
   }
 
   /**
@@ -69,14 +105,19 @@ export class PeekPanel {
     const memoryId = memory.memory_id || memory.id;
     this.state._detailCache = null;
 
+    // 竞态守卫：慢响应覆盖新点击/已关闭的面板（或关闭后自行重新打开）
+    const generation = ++this._detailGeneration;
+
     // 从 API 获取完整详情
     let detail = null;
     try {
       detail = await this.api.get("memories/detail", { memory_id: memoryId });
+      if (generation !== this._detailGeneration) return;
       if (detail) this.state._detailCache = detail;
     } catch (_) {
       detail = null;
     }
+    if (generation !== this._detailGeneration) return;
 
     // Fallback: 使用传入的 memory 数据
     if (!detail) {

--- a/pages/dashboard/modules/prompt-page.js
+++ b/pages/dashboard/modules/prompt-page.js
@@ -227,15 +227,21 @@ export class PromptPage {
       newResetBtn.addEventListener("click", () => this.resetPrompt());
       newCancelBtn.addEventListener("click", () => this.closeEditor());
 
-      // 检测修改
-      textarea.addEventListener("input", () => {
+      // 检测修改（textarea 是常驻节点，不能像按钮一样 clone 替换；
+      // 用可移除的具名 handler 防止每次打开编辑器都叠加监听）
+      if (this._textareaInputHandler) {
+        textarea.removeEventListener("input", this._textareaInputHandler);
+      }
+      this._textareaInputHandler = () => {
         // 手动编辑后退出恢复默认模式
         if (this._resetMode) {
           this._resetMode = false;
         }
         const modified = textarea.value !== this.editContent;
-        newSaveBtn.disabled = !modified;
-      });
+        const currentSaveBtn = document.getElementById("prompt-save-btn");
+        if (currentSaveBtn) currentSaveBtn.disabled = !modified;
+      };
+      textarea.addEventListener("input", this._textareaInputHandler);
       newSaveBtn.disabled = true;
       this._resetMode = false;
 

--- a/pages/dashboard/modules/recall-page.js
+++ b/pages/dashboard/modules/recall-page.js
@@ -47,6 +47,9 @@ export class RecallPage {
    * 执行召回测试
    */
   async runRecall() {
+    const searchBtn = document.getElementById("recall-search-btn");
+    // 回车触发不经过按钮 disabled 守卫，需显式防并发（慢响应覆盖新结果）
+    if (searchBtn && searchBtn.disabled) return;
     const query = document.getElementById("recall-query").value.trim();
     const k = parseInt(document.getElementById("recall-k").value) || 5;
     const sessionId = document.getElementById("recall-session").value.trim();
@@ -56,7 +59,6 @@ export class RecallPage {
       return;
     }
 
-    const searchBtn = document.getElementById("recall-search-btn");
     if (searchBtn) searchBtn.disabled = true;
 
     const startTime = Date.now();

--- a/pages/dashboard/modules/utils.js
+++ b/pages/dashboard/modules/utils.js
@@ -26,13 +26,17 @@ export function getDetailText(detail) {
 
 /**
  * HTML 转义，防止 XSS
+ *
+ * 必须转义引号：esc() 的输出会拼进 HTML 属性（如 value="..."、title="..."），
+ * 只转义 & < > 时属性值中的双引号可 breakout 注入任意属性/事件处理器。
+ * 同时避免每次调用分配 DOM 节点（虚拟滚动热路径）。
  * @param {string} text - 原始文本
- * @returns {string} 转义后的 HTML 安全文本
+ * @returns {string} 转义后的 HTML 安全文本（文本与属性上下文均安全）
  */
+const ESC_MAP = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
+
 export function esc(text) {
-  const div = document.createElement("div");
-  div.textContent = String(text);
-  return div.innerHTML;
+  return String(text).replace(/[&<>"']/g, (ch) => ESC_MAP[ch]);
 }
 
 /**

--- a/tests/frontend/escape.test.js
+++ b/tests/frontend/escape.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { esc } from "../../pages/dashboard/modules/utils.js";
+
+test("esc escapes quotes so interpolated attributes cannot break out", () => {
+  const payload = 'FACT" onfocus="alert(document.cookie)" autofocus="';
+  const rendered = '<input value="' + esc(payload) + '" />';
+  // The double quotes inside the payload must be entity-encoded
+  assert.equal(rendered.includes('" onfocus='), false);
+  assert.ok(rendered.includes("&quot;"));
+});
+
+test("esc escapes single quotes and core HTML metacharacters", () => {
+  assert.equal(esc("<img src=x onerror=alert(1)>"), "&lt;img src=x onerror=alert(1)&gt;");
+  assert.equal(esc("a&b'c\"d"), "a&amp;b&#39;c&quot;d");
+});
+
+test("esc is idempotent-safe for entity round trip in attribute context", () => {
+  const payload = '" onmouseover="x';
+  const html = '<input value="' + esc(payload) + '" />';
+  // no raw double quote from payload may survive inside the attribute value
+  assert.equal(html.includes(payload), false);
+  assert.equal(html, '<input value="&quot; onmouseover=&quot;x" />');
+});


### PR DESCRIPTION
## 摘要

WebUI 安全与交互修复（审计出的 2 个高危 + 5 个中危 + 若干小项）。

## 安全（高危）

**存储型 XSS**：`esc()` 此前经 `textContent → innerHTML` 只转义 `& < >`，**不转义引号**。而 `memory_type` 是自由文本（批量编辑对话框/LLM/导入均可写入），后端原样存储，前端在 `peek-panel.js` 编辑视图把它拼进 `value="..."` 属性 → 属性 breakout 可注入任意事件处理器，页面上下文持有完整插件 API bridge。修复：

- `esc()` 改为完整五字符转义（`& < > " '`），同时不再每次分配 DOM 节点（虚拟滚动热路径每帧 ~120 次调用）
- 新增回归测试锁定引号转义行为

## 交互/性能修复

| 问题 | 修复 |
|---|---|
| 虚拟滚动行高硬编码 56px，实际 ~63px，spacer 逐行漂移、末尾行不可达 | 首渲染后实测行高并复算窗口 |
| 删除后页码越界显示假空表 | 越界自动回退最后一页重取 |
| 图谱氛围动画在切页后（display:none）持续 30-60fps 空转 | `Graph2D.setActive()`，离开图谱页停 RAF、回来恢复（Worker 布局后台继续不受影响） |
| peek 详情请求无竞态守卫：慢响应覆盖新点击、关闭后面板自动重开 | generation 计数器（与 MemoryPage 同款模式） |
| Escape 键静默丢弃未保存编辑 | 分层处理：批量编辑对话框 → 确认框 → 编辑态回退详情 → 关闭面板 |
| POST 默认重试 2 次，`memories/update`（重建新 ID 语义）超时重试导致记忆重复创建 | POST 默认不重试（GET 保持 2 次），需重试的调用方显式声明 |
| 图谱/召回搜索回车绕过按钮 disabled 守卫，并发请求乱序覆盖 | in-flight 守卫 |
| 批量编辑对话框在面板关闭时 promise 永不 resolve（闭包泄漏） | `close()` 补 resolve(null) |
| prompt 编辑器 textarea 每次打开叠加 input 监听 | 具名 handler 先移除再绑定 |
| 图谱粒子相位表随查询无界增长、overview 每次重复请求 /stats | 数据重载时重置；去掉重复调用 |

## Testing

- [x] `npm run test:frontend` — 26 passed（含 3 个新增 esc 回归测试）
- [x] `uv run pytest -q` — 755 passed
- [x] 全部改动文件 `node --check` 通过
