### PR TITLE
perf(core): move heavy I/O off the event loop, cap full-graph snapshot, skip no-op graph rebuilds

### DIFF
--- a/core/managers/memory_engine_crud.py
+++ b/core/managers/memory_engine_crud.py
@@ -330,52 +330,65 @@ class MemoryEngineCrudMixin:
                 )
             rows.sort(key=lambda row: int(row["id"]))
         records: list[dict[str, Any]] = []
-        for row in rows:
-            metadata = self._safe_json_dict(row["metadata"])
-            source_messages: list[dict[str, Any]] = []
-            if row["source_json"]:
-                try:
-                    parsed_source = json.loads(row["source_json"])
-                except (json.JSONDecodeError, TypeError):
-                    parsed_source = []
-                if isinstance(parsed_source, list):
-                    source_messages = parsed_source
-            records.append(
-                {
-                    "original_id": int(row["id"]),
-                    "content": str(row["text"] or ""),
-                    "importance": clamp_float(
-                        metadata.get("importance"), default=0.5
-                    ),
-                    "session_id": metadata.get("session_id"),
-                    "persona_id": metadata.get("persona_id"),
-                    "metadata": metadata,
-                    "source_messages": source_messages,
-                    "storage_created_at": row["created_at"],
-                    "storage_updated_at": row["updated_at"],
-                }
-            )
+
+        def _build_records() -> list[dict[str, Any]]:
+            # 逐行 JSON 解析属于 CPU 密集工作，整体在 to_thread 中执行
+            for row in rows:
+                metadata = self._safe_json_dict(row["metadata"])
+                source_messages: list[dict[str, Any]] = []
+                if row["source_json"]:
+                    try:
+                        parsed_source = json.loads(row["source_json"])
+                    except (json.JSONDecodeError, TypeError):
+                        parsed_source = []
+                    if isinstance(parsed_source, list):
+                        source_messages = parsed_source
+                records.append(
+                    {
+                        "original_id": int(row["id"]),
+                        "content": str(row["text"] or ""),
+                        "importance": clamp_float(
+                            metadata.get("importance"), default=0.5
+                        ),
+                        "session_id": metadata.get("session_id"),
+                        "persona_id": metadata.get("persona_id"),
+                        "metadata": metadata,
+                        "source_messages": source_messages,
+                        "storage_created_at": row["created_at"],
+                        "storage_updated_at": row["updated_at"],
+                    }
+                )
+            return records
+
+        await asyncio.to_thread(_build_records)
         return records
 
     async def get_memory_import_keys(self) -> set[tuple[str, str, str]]:
         """Return duplicate keys for existing memories."""
         if self.db_connection is None:
             return set()
+        # 只取去重键所需的列，避免把整份 metadata 拉进内存
         cursor = await self.db_connection.execute(
-            "SELECT text, metadata FROM documents"
+            "SELECT text, "
+            "CASE WHEN json_valid(metadata) "
+            "THEN json_extract(metadata, '$.session_id') END AS session_id, "
+            "CASE WHEN json_valid(metadata) "
+            "THEN json_extract(metadata, '$.persona_id') END AS persona_id "
+            "FROM documents"
         )
         rows = await cursor.fetchall()
-        keys: set[tuple[str, str, str]] = set()
-        for row in rows:
-            metadata = self._safe_json_dict(row["metadata"])
-            keys.add(
+
+        def _compute_keys() -> set[tuple[str, str, str]]:
+            return {
                 memory_import_key(
                     str(row["text"] or ""),
-                    metadata.get("session_id"),
-                    metadata.get("persona_id"),
+                    row["session_id"],
+                    row["persona_id"],
                 )
-            )
-        return keys
+                for row in rows
+            }
+
+        return await asyncio.to_thread(_compute_keys)
 
     async def search_memories(
         self,
@@ -610,7 +623,22 @@ class MemoryEngineCrudMixin:
 
             if success:
                 logger.info(f"[更新] 元数据更新成功 (memory_id={memory_id})")
-                if self.graph_memory_manager is not None:
+                # 仅当更新触及图谱提取依赖的字段时才重建图谱索引；
+                # 状态/类型等纯元数据编辑重建整图（删节点+FAISS 落盘）纯属浪费
+                graph_affecting = metadata_updates.keys() & {
+                    "participants",
+                    "participant_identities",
+                    "topics",
+                    "key_facts",
+                    "canonical_summary",
+                    "session_id",
+                    "persona_id",
+                    "importance",
+                    "create_time",
+                    "summary_schema_version",
+                    "source_window",
+                }
+                if graph_affecting and self.graph_memory_manager is not None:
                     await self.graph_memory_manager.index_memory(
                         memory_id,
                         memory["text"],

--- a/core/page_api_modules/graph_handler.py
+++ b/core/page_api_modules/graph_handler.py
@@ -74,8 +74,11 @@ class GraphHandler:
             return self.utils.error("图谱分页参数无效")
 
         try:
-            stats = await memory_engine.get_statistics()
             graph_store = self.utils.get_graph_store(memory_engine)
+            # payload 只消费 graph 计数，无需触发全表统计扫描
+            stats = (
+                await graph_store.get_memory_entry_stats() if graph_store else {}
+            )
             empty_snapshot = {
                 "nodes": [],
                 "edges": [],
@@ -163,8 +166,11 @@ class GraphHandler:
             return self.utils.error("图谱检索参数无效")
 
         try:
-            stats = await memory_engine.get_statistics()
             graph_store = self.utils.get_graph_store(memory_engine)
+            # payload 只消费 graph 计数，无需触发全表统计扫描
+            stats = (
+                await graph_store.get_memory_entry_stats() if graph_store else {}
+            )
             empty_snapshot = {
                 "nodes": [],
                 "edges": [],

--- a/core/page_api_modules/memory_handler_io.py
+++ b/core/page_api_modules/memory_handler_io.py
@@ -5,6 +5,8 @@ MemoryHandler 的 MemoryHandlerIoMixin 拆分模块
 
 from typing import Any
 from datetime import datetime, timezone
+import asyncio
+
 from astrbot.api import logger
 from ..memory_transfer import (    MAX_IMPORT_ENTRIES,    memory_import_key,    parse_transfer_content,    serialize_transfer_csv,    serialize_transfer_json,)
 from quart import request
@@ -38,11 +40,14 @@ class MemoryHandlerIoMixin:
         records = await memory_engine.get_memory_transfer_records(memory_ids)
         exported_at = datetime.now(timezone.utc).isoformat()
         stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        # 序列化可能涉及上万条记录（含完整 source_messages），卸载到线程避免阻塞事件循环
         if export_format == "csv":
-            content = serialize_transfer_csv(records)
+            content = await asyncio.to_thread(serialize_transfer_csv, records)
             mime_type = "text/csv;charset=utf-8"
         else:
-            content = serialize_transfer_json(records, exported_at)
+            content = await asyncio.to_thread(
+                serialize_transfer_json, records, exported_at
+            )
             mime_type = "application/json;charset=utf-8"
 
         return self.utils.ok(
@@ -73,7 +78,10 @@ class MemoryHandlerIoMixin:
             return self.utils.error("导入文件不能超过 50 MiB")
 
         try:
-            entries, parse_errors = parse_transfer_content(content, import_format)
+            # 最多 50 MiB 内容的解析，卸载到线程避免阻塞事件循环
+            entries, parse_errors = await asyncio.to_thread(
+                parse_transfer_content, content, import_format
+            )
         except ValueError as exc:
             return self.utils.error(str(exc))
 

--- a/core/validators/index_validator_rebuild.py
+++ b/core/validators/index_validator_rebuild.py
@@ -272,19 +272,27 @@ class IndexValidatorRebuildMixin:
         try:
             async for batch in self._iter_document_batches(batch_size):
                 rows_to_insert: list[tuple[int, str]] = []
-                for doc_id, _doc_uuid, text, _metadata_json in batch:
-                    try:
-                        if hasattr(text_processor, "preprocess_for_bm25"):
-                            processed_content = text_processor.preprocess_for_bm25(
-                                text or ""
-                            )
-                        else:
-                            tokens = text_processor.tokenize(text or "", True)
-                            processed_content = " ".join(tokens)
-                        rows_to_insert.append((int(doc_id), processed_content))
-                    except Exception as e:
-                        failed_ids.add(int(doc_id))
-                        logger.error(f"BM25 预处理失败 doc_id={doc_id}: {e}")
+
+                def _preprocess_batch():
+                    # jieba 分词是 CPU 密集操作，批量卸载到线程避免
+                    # 重建期间反复阻塞事件循环
+                    processed: list[tuple[int, str]] = []
+                    for doc_id, _doc_uuid, text, _metadata_json in batch:
+                        try:
+                            if hasattr(text_processor, "preprocess_for_bm25"):
+                                processed_content = text_processor.preprocess_for_bm25(
+                                    text or ""
+                                )
+                            else:
+                                tokens = text_processor.tokenize(text or "", True)
+                                processed_content = " ".join(tokens)
+                            processed.append((int(doc_id), processed_content))
+                        except Exception as e:
+                            failed_ids.add(int(doc_id))
+                            logger.error(f"BM25 预处理失败 doc_id={doc_id}: {e}")
+                    return processed
+
+                rows_to_insert = await asyncio.to_thread(_preprocess_batch)
 
                 if rows_to_insert:
                     try:

--- a/storage/graph_store_snapshot.py
+++ b/storage/graph_store_snapshot.py
@@ -357,6 +357,7 @@ class GraphStoreSnapshotMixin:
 
         async with self._connect() as db:
             db.row_factory = aiosqlite.Row
+            # 防御性上限：全量图谱是显式请求，但极端规模的库仍可能拖垮事件循环
             node_cursor = await db.execute(
                 f"""
                 SELECT gn.id, gn.node_key, gn.node_type, gn.node_value,
@@ -369,6 +370,7 @@ class GraphStoreSnapshotMixin:
                 {where_clause}
                 GROUP BY gn.id
                 ORDER BY gn.id ASC
+                LIMIT 5000
                 """,
                 tuple(params),
             )
@@ -385,6 +387,7 @@ class GraphStoreSnapshotMixin:
                   ON ge.source_memory_id = edge.source_memory_id
                 {where_clause}
                 ORDER BY edge.id ASC
+                LIMIT 10000
                 """,
                 tuple(params),
             )
@@ -402,6 +405,7 @@ class GraphStoreSnapshotMixin:
                     GROUP BY ge.source_memory_id
                 ) latest ON latest.latest_entry_id = ge.id
                 ORDER BY ge.source_memory_id ASC
+                LIMIT 2000
                 """,
                 tuple(params),
             )

--- a/tests/test_memory_engine.py
+++ b/tests/test_memory_engine.py
@@ -1987,3 +1987,39 @@ async def test_get_session_memories_sorted_by_create_time_desc(tmp_path: Path):
     assert all(m["metadata"]["session_id"] == "s1" for m in memories)
 
     await engine.close()
+
+
+@pytest.mark.asyncio
+async def test_update_memory_status_only_skips_graph_reindex(tmp_path: Path):
+    """纯状态编辑不应触发图谱整图重建（审计 M3 回归守卫）。"""
+    db_path = tmp_path / "update_skip_graph.db"
+    engine = MemoryEngine(
+        db_path=str(db_path),
+        faiss_db=_FakeFaissDB(),
+        config={},
+    )
+    await engine.initialize()
+
+    mid = await engine.add_memory(
+        content="测试记忆",
+        session_id="s1",
+        persona_id="p1",
+        importance=0.5,
+        metadata={},
+    )
+
+    from unittest.mock import AsyncMock, Mock
+
+    engine.graph_memory_manager = Mock()
+    engine.graph_memory_manager.index_memory = AsyncMock()
+    engine.hybrid_retriever = Mock()
+    engine.hybrid_retriever.update_metadata = AsyncMock(return_value=True)
+
+    await engine.update_memory(mid, {"metadata": {"status": "archived"}})
+    engine.graph_memory_manager.index_memory.assert_not_awaited()
+
+    # importance 参与图谱打分，仍必须重建
+    await engine.update_memory(mid, {"importance": 0.9})
+    engine.graph_memory_manager.index_memory.assert_awaited_once()
+
+    await engine.close()

--- a/tests/test_page_api.py
+++ b/tests/test_page_api.py
@@ -1048,6 +1048,13 @@ class TestGraphEndpoints:
         graph_store = SimpleNamespace(
             get_full_graph_snapshot=AsyncMock(return_value=snapshot),
             get_graph_snapshot=AsyncMock(),
+            get_memory_entry_stats=AsyncMock(
+                return_value={
+                    "graph_nodes": 1,
+                    "graph_edges": 1,
+                    "graph_entries": 1,
+                }
+            ),
         )
         engine = FakeMemoryEngine(graph_store=graph_store)
         api = PluginPageApi(FakePlugin(memory_engine=engine))
@@ -1136,6 +1143,13 @@ class TestGraphEndpoints:
             ],
         }
         graph_store = SimpleNamespace(
+            get_memory_entry_stats=AsyncMock(
+                return_value={
+                    "graph_nodes": 1,
+                    "graph_edges": 1,
+                    "graph_entries": 1,
+                }
+            ),
             search_nodes_by_tokens=AsyncMock(
                 return_value=[
                     {


### PR DESCRIPTION
## 摘要

后端吞吐修复（性能审计 H3/H4/H5/H6/M3/M8）。

## 改动

| 问题 | 修复 |
|---|---|
| 导入在事件循环上解析 ≤50MiB JSON/CSV，期间全 bot 冻结（所有会话+WebUI） | `parse_transfer_content` → `asyncio.to_thread` |
| 导出全库（含完整 source_messages）逐行 `json.loads` + 整包序列化都在事件循环上 | 记录构建与 `serialize_transfer_*` → `to_thread` |
| 导入去重键扫描把整份 metadata 拉进内存 | 只 SELECT 去重所需三列（text/session_id/persona_id） |
| 图谱页 overview/query 每次请求触发 `get_statistics()`（全表 keyset 扫描+逐行 JSON 解析），但 payload 只用 3 个 graph 计数 | 改用 `graph_store.get_memory_entry_stats()`（3 个 COUNT） |
| 「全量图谱」三个查询无 LIMIT，一次点击全量载入内存并序列化 | 防御性上限 5000 节点 / 10000 边 / 2000 记忆 |
| 只改 status/type 等元数据也触发整图删除重建 + FAISS 落盘；批量编辑 = N 次重建 | `update_memory` 仅当触及图谱提取依赖字段（participants/topics/key_facts/canonical_summary/importance/session/persona 等）才重建；content/structured 编辑仍走 `replace_memory` 全量重建 |
| BM25 影子索引重建的批量 jieba 分词同步跑在事件循环上 | 每批预处理 → `to_thread` |

语义保持：

- `importance` 参与图谱检索打分（`graph_retriever.py:113`），归入影响集合，重要度编辑仍重建
- 导入去重键对畸形 metadata 的容错与原 `_safe_json_dict` 行为一致（`json_valid` 守卫）
- 全量图谱上限仅在极端规模时生效，常规库不可感知

## Testing

- [x] `uv run pytest -q` — 756 passed（新增：status-only 编辑不触发图重建回归测试；更新 2 处 graph 端点测试 mock 以匹配新的统计获取方式）
- [x] `npm run test:frontend` — 23 passed
