### PR TITLE
perf: move FAISS index persistence off the event loop

### DIFF
--- a/core/faiss_async_persist.py
+++ b/core/faiss_async_persist.py
@@ -1,0 +1,225 @@
+"""FAISS 索引异步落盘（变更锁 + 线程写盘 + 防抖合并）。
+
+背景：AstrBot 的 ``EmbeddingStorage.save_index()`` 在事件循环上同步执行
+``faiss.write_index``，对整个索引做整文件重写。索引随记忆增长到数百 MB 后，
+每次新增/删除记忆都会阻塞事件循环数秒，慢盘服务器上甚至达到分钟级。
+
+本模块在**实例级**替换 ``save_index``，并给 ``insert``/``insert_batch``/``delete``
+套上一把变更锁：
+
+1. 变更锁（asyncio.Lock）把「修改索引」与「写盘」串行化。写盘全程持锁，
+   faiss 序列化索引期间不会被并发的 add_with_ids/remove_ids 改动；代价是
+   写盘期间新的增删要排队，但排队发生在后台协程里，不阻塞事件循环；
+2. 写盘在单线程 executor 中执行 ``faiss.write_index``：流式写盘，不额外占用
+   与索引等量的内存；先写同目录临时文件再 ``os.replace`` 原子覆盖，同卷
+   rename 原子，进程中途被杀不会留下写了一半的索引文件。含非 ASCII 字符的
+   Windows 路径由插件已有的 ``faiss.write_index`` monkey-patch 负责桥接
+   （见 core/plugin_initializer_faiss.py）；
+3. 防抖合并：``save_index`` 只标记脏并排一个延迟落盘任务，任务醒来时若已有
+   更新的落盘请求（序号守卫）就直接跳过，于是窗口内的多次变更只写盘一次。
+
+读路径（search）不进锁：写盘只读索引，与查询并发安全（本插件只使用
+IndexIDMap(IndexFlatL2)，其查询不在索引上留下可变状态）。
+
+代价：防抖窗口内进程崩溃会丢失最近几秒未落盘的向量变更。
+启动时的索引校验（core/validators/）会对账 documents 表与索引并自动修复，
+该丢失在既有兜底能力范围内。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import functools
+import os
+import tempfile
+from typing import Any
+
+from astrbot.api import logger
+
+_PERSISTER_ATTR = "_async_index_persister"
+# 会被变更锁包裹的索引写方法（save_index 单独整体替换）
+_MUTATION_METHODS = ("insert", "insert_batch", "delete")
+# 默认防抖窗口：窗口内的多次索引变更合并为一次落盘
+DEFAULT_DEBOUNCE_SECONDS = 3.0
+
+
+def _write_index_atomic(index: Any, path: str) -> None:
+    """把索引原子写入 path（在 executor 线程中执行）。
+
+    同目录临时文件 + os.replace：保证 rename 同卷原子，进程中途被杀
+    也不会留下写了一半的索引文件。
+    """
+    import faiss
+
+    dirname = os.path.dirname(path) or "."
+    os.makedirs(dirname, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(prefix=".lmem_faiss_", suffix=".tmp", dir=dirname)
+    os.close(fd)
+    try:
+        faiss.write_index(index, tmp_path)
+        os.replace(tmp_path, path)
+    finally:
+        if os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+
+
+class AsyncIndexPersister:
+    """把某个 EmbeddingStorage 实例的落盘替换为防抖异步写。"""
+
+    def __init__(
+        self, storage: Any, debounce_seconds: float = DEFAULT_DEBOUNCE_SECONDS
+    ) -> None:
+        self._storage = storage
+        self._debounce_seconds = max(0.0, float(debounce_seconds))
+        self._mutation_lock = asyncio.Lock()
+        # 单线程 executor：写盘严格按提交顺序串行
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="lmem-faiss-flush"
+        )
+        self._debounce_tasks: set[asyncio.Task] = set()
+        self._pending_write: asyncio.Future | None = None
+        self._dirty = False
+        self._seq = 0
+        self._closed = False
+
+    def wrap_mutation_methods(self) -> None:
+        """给 insert/insert_batch/delete 套上变更锁（实例级）。"""
+        for name in _MUTATION_METHODS:
+            original = getattr(self._storage, name, None)
+            if not callable(original):
+                continue
+
+            @functools.wraps(original)
+            async def wrapper(*args, _original=original, **kwargs):
+                async with self._mutation_lock:
+                    return await _original(*args, **kwargs)
+
+            setattr(self._storage, name, wrapper)
+
+    async def save_index(self) -> None:
+        """替换后的 save_index：标记脏并排一个延迟落盘任务。
+
+        这里不取消上一个延迟任务：任务醒来后靠序号守卫判断自己是否已过期，
+        合并效果与取消相同；而取消一个已进入写盘的任务，会在写盘线程仍在
+        运行时释放变更锁，使后续增删与写盘并发。
+        """
+        if self._closed:
+            return
+        if self._storage.index is None or not self._storage.path:
+            return
+        self._dirty = True
+        self._seq += 1
+        task = asyncio.create_task(self._debounced_flush(self._seq))
+        self._debounce_tasks.add(task)
+        task.add_done_callback(self._debounce_tasks.discard)
+
+    async def _debounced_flush(self, seq: int) -> None:
+        try:
+            if self._debounce_seconds > 0:
+                await asyncio.sleep(self._debounce_seconds)
+            await self._do_flush(seq)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # dirty 保持为 True，下次变更或 flush_now 会重试
+            logger.error("[FAISS] 索引异步落盘失败，将在下次变更时重试", exc_info=True)
+
+    async def _do_flush(self, seq: int) -> None:
+        if seq != self._seq or not self._dirty:
+            # 已有更新的落盘请求排队，跳过本次，省一次整文件 I/O
+            return
+        loop = asyncio.get_running_loop()
+        async with self._mutation_lock:
+            if not self._dirty:
+                # 等锁期间已被另一次落盘写掉
+                return
+            storage = self._storage
+            index = storage.index
+            path = storage.path
+            if index is None or not path:
+                self._dirty = False
+                return
+            fut = loop.run_in_executor(self._executor, _write_index_atomic, index, path)
+            self._pending_write = fut
+            try:
+                await fut
+            finally:
+                if self._pending_write is fut:
+                    self._pending_write = None
+            # 写盘全程持锁，落盘内容即当前索引状态，脏标记可整体清掉
+            self._dirty = False
+
+    async def flush_now(self) -> None:
+        """立即落盘未写变更，并等待进行中的写盘完成。
+
+        索引重建换文件（core/validators/index_validator_rebuild.py）之前必须调用：
+        飞行中的落盘写的是换文件之前的索引对象，若在 os.replace 之后才落地，
+        会把刚重建好的索引文件覆盖掉。
+        """
+        if self._closed:
+            return
+        # 序号自增使所有已排队的延迟落盘任务失效，无需逐个取消
+        self._seq += 1
+        if self._dirty:
+            await self._do_flush(self._seq)
+        pending = self._pending_write
+        if pending is not None:
+            await pending
+
+    async def aclose(self) -> None:
+        """落盘剩余变更并关闭写盘线程（插件卸载前调用，幂等）。"""
+        if self._closed:
+            return
+        self._closed = True
+        self._seq += 1
+        # 取消仍在等待防抖窗口的落盘任务，并等它们解开（可能持有变更锁）
+        pending_tasks = list(self._debounce_tasks)
+        for task in pending_tasks:
+            task.cancel()
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+        try:
+            if self._dirty:
+                await self._do_flush(self._seq)
+            pending = self._pending_write
+            if pending is not None:
+                await pending
+        except Exception:
+            logger.error("[FAISS] 关闭前落盘索引失败", exc_info=True)
+        # 关线程池交给默认线程池执行：极端情况下仍有飞行中的写盘时，
+        # 不在事件循环上同步等待整文件写完
+        await asyncio.get_running_loop().run_in_executor(
+            None, self._executor.shutdown, True
+        )
+
+
+def get_async_persister(storage: Any) -> AsyncIndexPersister | None:
+    """返回已安装在 storage 上的 persister，未安装则返回 None。"""
+    if storage is None:
+        return None
+    return getattr(storage, _PERSISTER_ATTR, None)
+
+
+def install_async_persist(
+    storage: Any, debounce_seconds: float = DEFAULT_DEBOUNCE_SECONDS
+) -> AsyncIndexPersister | None:
+    """在实例级替换 storage 的落盘行为为异步防抖写。
+
+    只改单个实例的实例属性，不影响 EmbeddingStorage 类和其他实例。
+    已安装过则复用原实例；storage 无索引路径（纯内存模式）时返回 None。
+    """
+    if storage is None or not getattr(storage, "path", None):
+        return None
+    existing = get_async_persister(storage)
+    if existing is not None:
+        return existing
+    persister = AsyncIndexPersister(storage, debounce_seconds)
+    # 先给变更方法套锁，再替换 save_index，保证写盘期间索引静止
+    persister.wrap_mutation_methods()
+    storage.save_index = persister.save_index
+    setattr(storage, _PERSISTER_ATTR, persister)
+    return persister

--- a/core/plugin_initializer.py
+++ b/core/plugin_initializer.py
@@ -60,6 +60,8 @@ class PluginInitializer(InitializerFaissMixin, InitializerFinalizeMixin):
         self.llm_provider: Provider | None = None
         self.db: Any | None = None
         self.graph_db: Any | None = None
+        # FAISS 索引异步落盘器（core/faiss_async_persist.py），随 db/graph_db 创建
+        self._index_persisters: list = []
         self.memory_engine: MemoryEngine | None = None
         self.memory_processor: MemoryProcessor | None = None
         self.db_migration: DBMigration | None = None

--- a/core/plugin_initializer_finalize.py
+++ b/core/plugin_initializer_finalize.py
@@ -12,6 +12,7 @@ from .schedulers.decay_scheduler import DecayScheduler
 from .validators.index_validator import IndexValidator
 from .base.exceptions import InitializationError, ProviderNotReadyError
 from astrbot.api import logger
+from .faiss_async_persist import install_async_persist
 from .managers.consolidation_manager import MemoryConsolidationManager
 from .managers.memory_engine import MemoryEngine
 from .processors.memory_processor import MemoryProcessor
@@ -67,6 +68,15 @@ class InitializerFinalizeMixin:
                 )
                 await self.graph_db.initialize()
             logger.info(f"数据库已初始化。数据目录: {self.data_dir}")
+
+            # 实例级替换 save_index：变更锁 + 线程内直写 + 防抖合并，
+            # 避免大索引整文件同步写阻塞事件循环（详见 core/faiss_async_persist.py）
+            self._index_persisters = []
+            for vec_db in (self.db, self.graph_db):
+                storage = getattr(vec_db, "embedding_storage", None)
+                persister = install_async_persist(storage)
+                if persister is not None:
+                    self._index_persisters.append(persister)
 
             # 初始化数据库迁移管理器
             self.db_migration = DBMigration(str(db_path))
@@ -604,8 +614,21 @@ class InitializerFinalizeMixin:
         except Exception as e:
             logger.error(f"修复 message_count 失败: {e}", exc_info=True)
 
+    async def shutdown_index_persisters(self) -> None:
+        """落盘并停止所有索引异步落盘器（terminate / 重新初始化前调用，幂等）。"""
+        persisters = getattr(self, "_index_persisters", None) or []
+        self._index_persisters = []
+        for persister in persisters:
+            try:
+                await persister.aclose()
+            except Exception:
+                logger.warning("关闭索引异步落盘器失败", exc_info=True)
+
     async def _teardown_partial_init(self) -> None:
         """关闭初始化过程中已创建的资源，使后续重试可以从干净状态开始。"""
+        # 先落盘索引未写变更，再关闭各存储组件
+        await self.shutdown_index_persisters()
+
         if self.decay_scheduler is not None:
             try:
                 await self.decay_scheduler.stop()

--- a/core/validators/index_validator_rebuild.py
+++ b/core/validators/index_validator_rebuild.py
@@ -11,6 +11,8 @@ from astrbot.api import logger
 import os
 import time
 
+from ..faiss_async_persist import get_async_persister
+
 
 class IndexValidatorRebuildMixin:
     """IndexValidator 拆分模块：IndexValidatorRebuildMixin"""
@@ -684,6 +686,15 @@ class IndexValidatorRebuildMixin:
 
         if index_path:
             await persist_checkpoint()
+            # 排空异步落盘器：飞行中的落盘写的是换文件之前的索引对象，
+            # 若在 os.replace 之后才落地，会覆盖刚换入的重建文件。
+            # flush_now 与 os.replace 之间不得有 await，否则窗口会重新打开。
+            persister = get_async_persister(embedding_storage)
+            if persister is not None:
+                try:
+                    await persister.flush_now()
+                except Exception:
+                    logger.warning("重建前落盘旧索引失败，继续重建流程", exc_info=True)
             if temp_path:
                 os.replace(temp_path, index_path)
             if metadata_path and os.path.exists(metadata_path):

--- a/main.py
+++ b/main.py
@@ -608,6 +608,9 @@ class LivingMemoryPlugin(Star):
             await self.initializer.conversation_manager.store.close()
             logger.info("ConversationManager 已关闭")
 
+        # 关闭 FaissVecDB 之前，先把索引的未落盘变更写掉
+        await self.initializer.shutdown_index_persisters()
+
         # 关闭 MemoryEngine
         if self.initializer.memory_engine:
             await self.initializer.memory_engine.close()

--- a/tests/integration/test_plugin_lifecycle_integration.py
+++ b/tests/integration/test_plugin_lifecycle_integration.py
@@ -26,6 +26,7 @@ class _FakeInitializer:
         self.ensure_initialized = AsyncMock(return_value=False)
         self.stop_background_tasks = AsyncMock()
         self.stop_scheduler = AsyncMock()
+        self.shutdown_index_persisters = AsyncMock()
 
     @property
     def is_initialized(self) -> bool:

--- a/tests/test_faiss_async_persist.py
+++ b/tests/test_faiss_async_persist.py
@@ -1,0 +1,250 @@
+"""
+FAISS 索引异步落盘（core/faiss_async_persist.py）测试。
+"""
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+import faiss
+import numpy as np
+import pytest
+
+from astrbot_plugin_livingmemory.core import faiss_async_persist
+from astrbot_plugin_livingmemory.core.faiss_async_persist import (
+    get_async_persister,
+    install_async_persist,
+)
+
+
+class _DummyEmbeddingStorage:
+    """最小化模拟 AstrBot EmbeddingStorage：真实 faiss 索引 + 真实文件路径。"""
+
+    def __init__(self, index_path: Path, dimension: int = 8):
+        self.dimension = dimension
+        self.path = str(index_path)
+        self.index = faiss.IndexIDMap(faiss.IndexFlatL2(dimension))
+
+    @staticmethod
+    def _write_index(index, path) -> None:
+        faiss.write_index(index, path)
+
+    async def save_index(self) -> None:
+        # 与 AstrBot 一致的原始行为：同步整文件写
+        if self.index is None or not self.path:
+            return
+        self._write_index(self.index, self.path)
+
+    async def insert_batch(self, vectors: np.ndarray, ids: list[int]) -> None:
+        # 与 AstrBot 一致：先改索引再触发 save_index
+        self.index.add_with_ids(vectors, np.asarray(ids, dtype=np.int64))
+        await self.save_index()
+
+
+def _add_vectors(storage: _DummyEmbeddingStorage, start_id: int, count: int) -> None:
+    vectors = np.random.rand(count, storage.dimension).astype(np.float32)
+    ids = np.arange(start_id, start_id + count, dtype=np.int64)
+    storage.index.add_with_ids(vectors, ids)
+
+
+def _make_storage(tmp_path: Path, name: str = "test.index") -> _DummyEmbeddingStorage:
+    return _DummyEmbeddingStorage(tmp_path / name)
+
+
+@pytest.mark.asyncio
+async def test_save_index_debounces_into_single_write(tmp_path, monkeypatch):
+    """防抖窗口内的多次 save_index 只落盘一次。"""
+    storage = _make_storage(tmp_path)
+    _add_vectors(storage, 0, 10)
+    persister = install_async_persist(storage, debounce_seconds=0.05)
+
+    write_count = 0
+    real_write = faiss_async_persist._write_index_atomic
+
+    def counting_write(index, path):
+        nonlocal write_count
+        write_count += 1
+        real_write(index, path)
+
+    monkeypatch.setattr(faiss_async_persist, "_write_index_atomic", counting_write)
+
+    for _ in range(5):
+        await storage.save_index()
+    # 防抖窗口未结束，不应有任何写盘
+    assert write_count == 0
+
+    await asyncio.sleep(0.3)
+    assert write_count == 1
+
+    loaded = faiss.read_index(storage.path)
+    assert loaded.ntotal == 10
+    await persister.aclose()
+
+
+@pytest.mark.asyncio
+async def test_flush_now_writes_pending_immediately(tmp_path):
+    """长防抖窗口下 flush_now 立即落盘且文件可读回。"""
+    storage = _make_storage(tmp_path)
+    _add_vectors(storage, 0, 20)
+    persister = install_async_persist(storage, debounce_seconds=600)
+
+    await storage.save_index()
+    assert not Path(storage.path).exists()
+
+    await persister.flush_now()
+    loaded = faiss.read_index(storage.path)
+    assert loaded.ntotal == 20
+    await persister.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mutation_during_inflight_flush(tmp_path):
+    """落盘进行中的并发写入不崩溃，最终文件内容与内存索引一致。"""
+    storage = _make_storage(tmp_path)
+    _add_vectors(storage, 0, 500)
+    persister = install_async_persist(storage, debounce_seconds=0)
+
+    await storage.save_index()
+    # 让第一次落盘先开始（写盘在 executor 线程）
+    await asyncio.sleep(0.05)
+    # 走被变更锁包裹的 insert_batch：排在进行中的写盘之后，不与其并发改索引
+    vectors = np.random.rand(500, storage.dimension).astype(np.float32)
+    await storage.insert_batch(vectors, list(range(500, 1000)))
+
+    await persister.flush_now()
+    loaded = faiss.read_index(storage.path)
+    assert loaded.ntotal == storage.index.ntotal == 1000
+    await persister.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_flushes_pending_and_is_idempotent(tmp_path):
+    """aclose 落盘未写变更、关闭线程池，且可重复调用。"""
+    storage = _make_storage(tmp_path)
+    _add_vectors(storage, 0, 10)
+    persister = install_async_persist(storage, debounce_seconds=600)
+
+    await storage.save_index()
+    assert not Path(storage.path).exists()
+
+    await persister.aclose()
+    loaded = faiss.read_index(storage.path)
+    assert loaded.ntotal == 10
+
+    # 关闭后 save_index 静默忽略，aclose 幂等
+    _add_vectors(storage, 10, 5)
+    await storage.save_index()
+    await persister.aclose()
+    loaded = faiss.read_index(storage.path)
+    assert loaded.ntotal == 10
+
+
+@pytest.mark.asyncio
+async def test_zero_debounce_persists_without_delay(tmp_path):
+    """debounce=0 时每次变更立即安排异步落盘。"""
+    storage = _make_storage(tmp_path)
+    _add_vectors(storage, 0, 10)
+    persister = install_async_persist(storage, debounce_seconds=0)
+
+    await storage.save_index()
+    await persister.flush_now()
+    loaded = faiss.read_index(storage.path)
+    assert loaded.ntotal == 10
+    await persister.aclose()
+
+
+@pytest.mark.asyncio
+async def test_flush_now_guards_rebuild_file_swap(tmp_path, monkeypatch):
+    """索引重建换文件前必须先 flush_now 排空飞行中的落盘。
+
+    锁定 core/validators/index_validator_rebuild.py 中 flush_now 调用的必要性：
+    去掉它时，飞行中的旧索引落盘会在 os.replace 之后落地，覆盖重建结果。
+    """
+    storage = _make_storage(tmp_path)
+    _add_vectors(storage, 0, 2000)
+    persister = install_async_persist(storage, debounce_seconds=0)
+
+    real_write = faiss_async_persist._write_index_atomic
+
+    def slow_write(index, path):
+        # 放慢写盘，制造「换文件时落盘仍在飞行中」的真实窗口
+        time.sleep(0.3)
+        real_write(index, path)
+
+    monkeypatch.setattr(faiss_async_persist, "_write_index_atomic", slow_write)
+
+    # 重建产物：只含 50 条向量的新索引
+    rebuilt = faiss.IndexIDMap(faiss.IndexFlatL2(storage.dimension))
+    rebuilt.add_with_ids(
+        np.random.rand(50, storage.dimension).astype(np.float32),
+        np.arange(10_000, 10_050, dtype=np.int64),
+    )
+    temp_path = f"{storage.path}.rebuild.tmp"
+    faiss.write_index(rebuilt, temp_path)
+
+    await storage.save_index()
+    await asyncio.sleep(0.05)  # 旧索引落盘已进入飞行
+    await persister.flush_now()
+    os.replace(temp_path, storage.path)
+    storage.index = rebuilt
+    await asyncio.sleep(0.5)  # 给漏网的落盘留出落地时间
+
+    loaded = faiss.read_index(storage.path)
+    assert loaded.ntotal == 50, "重建结果被飞行中的旧索引落盘覆盖"
+    await persister.aclose()
+
+
+def test_install_is_per_instance_and_idempotent(tmp_path):
+    """实例级替换：不影响其他实例；重复安装复用同一 persister。"""
+    storage_a = _make_storage(tmp_path, "a.index")
+    storage_b = _make_storage(tmp_path, "b.index")
+
+    persister_a = install_async_persist(storage_a, debounce_seconds=1.0)
+    assert persister_a is not None
+    assert get_async_persister(storage_a) is persister_a
+    assert get_async_persister(storage_b) is None
+    # storage_b 的 save_index 仍是类方法，未被替换
+    assert "save_index" not in storage_b.__dict__
+
+    assert install_async_persist(storage_a, debounce_seconds=9.0) is persister_a
+
+
+def test_install_skips_storage_without_path(tmp_path):
+    """纯内存模式（无索引路径）不安装，与原 save_index 空操作语义一致。"""
+
+    class _MemoryOnlyStorage:
+        path = None
+        index = None
+
+    assert install_async_persist(_MemoryOnlyStorage(), 1.0) is None
+
+
+@pytest.mark.asyncio
+async def test_write_failure_keeps_dirty_for_retry(tmp_path, monkeypatch):
+    """写盘失败保持 dirty，下次 flush_now 可重试成功。"""
+    storage = _make_storage(tmp_path)
+    _add_vectors(storage, 0, 10)
+    persister = install_async_persist(storage, debounce_seconds=0)
+
+    real_write = faiss_async_persist._write_index_atomic
+    state = {"fail": True}
+
+    def flaky_write(index, path):
+        if state["fail"]:
+            raise OSError("disk full")
+        real_write(index, path)
+
+    monkeypatch.setattr(faiss_async_persist, "_write_index_atomic", flaky_write)
+
+    await storage.save_index()
+    with pytest.raises(OSError):
+        await persister.flush_now()
+    assert persister._dirty
+
+    state["fail"] = False
+    await persister.flush_now()
+    assert not persister._dirty
+    loaded = faiss.read_index(storage.path)
+    assert loaded.ntotal == 10
+    await persister.aclose()


### PR DESCRIPTION
## Summary

- 修复每次新增/删除记忆都会在事件循环上同步整文件重写 FAISS 索引（`livingmemory.index` / `livingmemory_graph.index`）导致整个 bot 冻结的问题。索引增长到数百 MB 后，单次写入阻塞事件循环数百毫秒到数秒；在低 IOPS 云盘上可达分钟级。
- 根因在 AstrBot `EmbeddingStorage.save_index()`：`async` 方法内直接同步调用 `faiss.write_index`，且 `insert` / `insert_batch` / `delete` 每次都无条件触发。插件侧存一条新记忆会走两次（文档索引 + 图谱索引）。
- 本 PR 在插件侧实例级接管落盘行为：写盘移入单线程 executor，事件循环零阻塞；变更锁保证写盘期间索引静止；防抖窗口（默认 3s）内的多次变更合并为一次落盘。

## Related Issues

- N/A

## Changes

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Tests
- [ ] Configuration / release metadata

实现要点（`core/faiss_async_persist.py`，新增）：

- `install_async_persist(storage)` 在实例级替换 `save_index`，并给 `insert` / `insert_batch` / `delete` 套一把变更锁（`asyncio.Lock`）；只写实例属性，不影响 `EmbeddingStorage` 类与其他实例。
- 落盘流程：持锁在 executor 线程中 `faiss.write_index` 写同目录临时文件，再 `os.replace` 原子覆盖。
  - 流式写盘，不额外占用与索引等量的内存（曾评估过 `serialize_index` 内存快照方案，实测 RSS 峰值为索引大小的 2 倍，412MB 索引即 +823MB，已放弃）。
  - 同目录临时文件保证 rename 同卷原子，进程中途被杀不会留下写了一半的索引文件。
  - 含非 ASCII 字符的 Windows 路径由插件已有的 `faiss.write_index` monkey-patch 桥接（`core/plugin_initializer_faiss.py`），本模块无需重复处理。
- 变更锁覆盖整个写盘过程，因此写盘期间新的增删要排队；排队发生在后台协程里，**不阻塞事件循环**，bot 照常响应。
- 防抖合并 + 序号守卫：`save_index` 只标记脏并排一个延迟任务，任务醒来时若已有更新的落盘请求就直接跳过；慢盘上不会排队重复写数百 MB。这里刻意不取消上一个延迟任务——取消一个已进入写盘的任务会在写盘线程仍在运行时释放变更锁，使后续增删与写盘并发。
- 崩溃窗口说明：防抖窗口内进程异常退出会丢失最近几秒未落盘的向量变更，启动时索引校验（`core/validators/`）会发现 documents 表与索引不一致并自动修复，属既有兜底能力范围。

接入点：

- `core/plugin_initializer_finalize.py`：初始化时为 `db` 与 `graph_db` 两个 `EmbeddingStorage` 实例各安装一个；新增 `shutdown_index_persisters()`（幂等），初始化失败清理路径 `_teardown_partial_init()` 一并调用。
- `main.py`：`terminate()` 在关闭 MemoryEngine / FaissVecDB 之前先落盘所有未写变更（顺序必须如此，`memory_engine.close()` 会关掉 `graph_db`）。
- `core/validators/index_validator_rebuild.py`：全量重建 `os.replace` 换文件之前先 `flush_now()` 排空飞行中的落盘，否则写的是换文件之前的索引对象、在 `os.replace` 之后落地会覆盖重建结果。`flush_now()` 与 `os.replace` 之间不得插入 `await`，否则窗口重新打开。

回滚考虑：纯新增实例级 patch，删除接入点即恢复原行为；落盘产物与原生 `faiss.write_index` 逐字节一致（已用 sha256 校验），旧版本插件/AstrBot 可直接读取。

## Testing

- [ ] `uv run pytest -q`
- [x] Manual verification:
  - `pytest tests/test_faiss_async_persist.py -q`：新增 9 项测试全部通过（防抖合并只写一次、`flush_now` 立即落盘可读回、写盘期间并发 `insert_batch`、`aclose` 强制落盘且幂等、零延迟档、重建换文件竞态回归、实例隔离与幂等安装、无路径跳过、写盘失败保脏重试）。
  - `pytest tests/ --ignore=tests/integration -q`：750 passed；4 个失败为 `tests/test_utils_extended.py` 时区相关用例，在未修改的 master 上同样失败（环境预置问题，与本 PR 无关）。
  - 重建竞态反向对照（临时脚本，放慢写盘制造飞行窗口）：不调 `flush_now` 时磁盘留下 2000 条旧向量、50 条重建结果全丢；调用 `flush_now` 后稳定保住 50 条。证明该调用必要，且已固化为回归测试 `test_flush_now_guards_rebuild_file_swap`。
  - 基准（本机 SSD，210k×512 维索引，落盘文件 412MB）：

    | 指标 | 改动前（循环上同步写） | 改动后 |
    | --- | --- | --- |
    | `save_index` 调用耗时 | 0.246 s | 0.000018 s |
    | 事件循环最大卡顿 | 0.249 s | 0.001 s |
    | 落盘总耗时 | 0.246 s | 0.442 s |
    | RSS 增量 | +0 MB | +0 MB |

    落盘期间一次 `insert` 排队等待 0.390 s（不阻塞事件循环）。慢盘场景差距更大：改动前的卡顿随磁盘写入时间线性增长，改动后与磁盘速度无关。
  - 落盘文件用 `faiss.read_index` 读回校验向量数一致；与原生 `faiss.write_index` 产物 sha256 一致；无残留临时文件；`aclose()` 后写盘线程已全部回收。

## Checklist

- [x] I have searched existing issues and pull requests.
- [x] I have updated documentation or configuration schema when needed.（未新增配置项，防抖窗口为模块常量 `DEFAULT_DEBOUNCE_SECONDS = 3.0`）
- [x] I have updated `metadata.yaml`, `main.py`, `CHANGELOG.md`, and version constants when this changes the released plugin version.（不涉及发版元数据）
- [x] I have added or updated tests for behavior changes.
